### PR TITLE
SI-9248 Improve test

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -575,7 +575,7 @@ trait Infer extends Checkable {
         )
       }
       if (settings.warnInferAny) {
-        foreachWithIndex(targs){ (targ, idx) =>
+        foreachWithIndex(targs) { (targ, idx) =>
           val tparam = tparams(idx)
           if (!tparam.isMonomorphicType && !targ.isHigherKinded)
             reporter.warning(argumentPosition(idx), s"type inference relied on kind-polymorphic nature of inferred type `$targ` to conform to type parameter ${tparam.defString}")

--- a/test/files/neg/t9248.check
+++ b/test/files/neg/t9248.check
@@ -1,4 +1,6 @@
-warning: there were two feature warnings; re-run with -feature for details
+t9248.scala:13: warning: type inference relied on kind-polymorphic nature of inferred type `Any` to conform to type parameter F[A]
+  def test3 = {
+              ^
 error: No warnings can be incurred under -Xfatal-warnings.
 one warning found
 one error found

--- a/test/files/neg/t9248.flags
+++ b/test/files/neg/t9248.flags
@@ -1,1 +1,1 @@
--Xfatal-warnings
+-Xfatal-warnings -language:_ -Xlint:infer-any

--- a/test/files/neg/t9248.scala
+++ b/test/files/neg/t9248.scala
@@ -6,14 +6,14 @@ object Test {
   def f[F[A], A](f: F[A]) = ???
   def test1(u: Unary[Any]) = f(u)
 
-  // reports inference error, cannot unifiy Binary[Any, Any] with ?F[?A]
+  // reports inference error, cannot unify Binary[Any, Any] with ?F[?A]
   // commented out as we can't have errors in a test for warnings.
   // def test2(u: Binary[Any, Any]) = f(u)
 
   def test3 = {
     implicit def b2u[A, B](b: Binary[A, B]): List[Int] = ???
     val b: Binary[Any, Any] = null
-    f(b) // inference fails initially, but then we try to coerse the arguments 
+    f(b) // inference fails initially, but then we try to coerce the arguments 
     //
     // Under -Ytyper-debug, we see:
     //
@@ -29,7 +29,7 @@ object Test {
     //
     // This leads to inference of ?F=Any, ?A=Nothing (this is kind-correct because Any/Nothing are kind polymorphic)
     // 
-    // When we instantatiate the method type of `f` with this, the formal parameter type is now just Any[Nothing]
+    // When we instantiate the method type of `f` with this, the formal parameter type is now just Any[Nothing]
     // which is just Any.
     //
     // The provided argument of type `Binary[A, B]` now unifies with this, no implicit coercion required.

--- a/test/files/neg/warn-inferred-any.check
+++ b/test/files/neg/warn-inferred-any.check
@@ -7,9 +7,12 @@ warn-inferred-any.scala:16: warning: a type was inferred to be `AnyVal`; this ma
 warn-inferred-any.scala:17: warning: a type was inferred to be `AnyVal`; this may indicate a programming error.
   { 1l to 5l contains 5d }
              ^
-warn-inferred-any.scala:25: warning: a type was inferred to be `Any`; this may indicate a programming error.
+warn-inferred-any.scala:26: warning: a type was inferred to be `Any`; this may indicate a programming error.
   def za = f(1, "one")
              ^
+warn-inferred-any.scala:27: warning: a type was inferred to be `Any`; this may indicate a programming error.
+  def zx = f2(1, "one")
+                 ^
 error: No warnings can be incurred under -Xfatal-warnings.
-four warnings found
+5 warnings found
 one error found

--- a/test/files/neg/warn-inferred-any.scala
+++ b/test/files/neg/warn-inferred-any.scala
@@ -20,8 +20,10 @@ trait Ys[+A] {
 
 trait Zs {
   def f[A](a: A*) = 42
+  def f2[X, A](a: A*) = 42     // fixme warns on the 2nd arg
   def g[A >: Any](a: A*) = 42  // don't warn
 
   def za = f(1, "one")
+  def zx = f2(1, "one")
   def zu = g(1, "one")
 }


### PR DESCRIPTION
The test shows that the lint warning doesn't have a useful position.

For certain applications, it will use the pos of any old arg.