### PR TITLE
Avoid typechecking val and def tpt-s twice

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1302,7 +1302,11 @@ trait Namers extends MethodSynthesis {
 
       val resTpGiven =
         if (tpt.isEmpty) WildcardType
-        else typer.typedType(tpt).tpe
+        else {
+          val tp = typer.typedType(tpt).tpe
+          ddef.tpt setType tp
+          tp
+        }
 
 
       // ignore missing types unless we can look to overridden method to recover the missing information
@@ -1429,7 +1433,9 @@ trait Namers extends MethodSynthesis {
         //   trait T { def f: A }; class C extends T { implicit def b2a(t: B): A = ???; def f = new B }
         val resTpComputedUnlessGiven =
           if (tpt.isEmpty) assignTypeToTree(ddef, typer, resTpFromOverride)
-          else resTpGiven
+          else {
+            resTpGiven
+          }
 
         // #2382: return type of default getters are always @uncheckedVariance
         if (meth.hasDefault) resTpComputedUnlessGiven.withAnnotation(AnnotationInfo(uncheckedVarianceClass.tpe, List(), List()))
@@ -1715,7 +1721,11 @@ trait Namers extends MethodSynthesis {
 
             tptFromRhsUnderPt
           }
-        } else typer.typedType(tpt).tpe
+        } else {
+          val tp = typer.typedType(tpt).tpe
+          vdef.tpt setType tp
+          tp
+        }
 
 //      println(s"val: $result / ${vdef.tpt.tpe} / ")
 

--- a/test/junit/scala/reflect/internal/PrintersTest.scala
+++ b/test/junit/scala/reflect/internal/PrintersTest.scala
@@ -267,7 +267,7 @@ class BasePrintTest {
     |}""",
     typedCode = sm"""
     |{
-    |  class foo[t](x: scala.Int);
+    |  class foo[t](x: Int);
     |  {
     |    final class $$anon extends foo[scala.Predef.String](3) {
     |      ()
@@ -327,12 +327,12 @@ class BasePrintTest {
   @Test def testFunc1 = assertResultCode(
     code = "List(1, 2, 3).map((i: Int) => i - 1)")(
     parsedCode = "List(1, 2, 3).map(((i: Int) => i.-(1)))",
-    typedCode = sm"scala.collection.immutable.List.apply[Int](1, 2, 3).map[Int, List[Int]](((i: scala.Int) => i.-(1)))(scala.collection.immutable.List.canBuildFrom[Int])")
+    typedCode = sm"scala.collection.immutable.List.apply[Int](1, 2, 3).map[Int, List[Int]](((i: Int) => i.-(1)))(scala.collection.immutable.List.canBuildFrom[Int])")
 
   @Test def testFunc2 = assertResultCode(
     code = "val sum: Seq[Int] => Int = _ reduceLeft (_+_)")(
     parsedCode = "val sum: _root_.scala.Function1[Seq[Int], Int] = ((x$1) => x$1.reduceLeft(((x$2, x$3) => x$2.+(x$3))))",
-    typedCode = "val sum: _root_.scala.Function1[scala.`package`.Seq[scala.Int], scala.Int] = ((x$1: Seq[Int]) => x$1.reduceLeft[Int](((x$2: Int, x$3: Int) => x$2.+(x$3))))")
+    typedCode = "val sum: _root_.scala.Function1[Seq[Int], Int] = ((x$1: Seq[Int]) => x$1.reduceLeft[Int](((x$2: Int, x$3: Int) => x$2.+(x$3))))")
 
   @Test def testFunc3 = assertResultCode(
     code = "List(1, 2, 3) map (_ - 1)")(
@@ -342,7 +342,7 @@ class BasePrintTest {
   @Test def testFunc4 = assertResultCode(
     code = "val x: String => Int = ((str: String) => 1)")(
     parsedCode = "val x: _root_.scala.Function1[String, Int] = ((str: String) => 1)",
-    typedCode = " val x: _root_.scala.Function1[_root_.scala.Predef.String, _root_.scala.Int] = ((str: _root_.scala.Predef.String) => 1)", printRoot = true)
+    typedCode = " val x: _root_.scala.Function1[String, Int] = ((str: String) => 1)", printRoot = true)
 
   @Test def testAssign1 = assertPrintedCode("(f.v = 5).toString", checkTypedTree = false)
   
@@ -832,7 +832,7 @@ class ClassPrintTest {
     typedCode = sm"""
     |object Test {
     |  import java.io._;
-    |  var file: java.io.PrintStream = null;
+    |  var file: PrintStream = null;
     |  try {
     |    val out = new java.io.FileOutputStream("myfile.txt");
     |    Test.this.`file_=`(new java.io.PrintStream(out))


### PR DESCRIPTION
While working on build pipelining + outline typing, I noticed we're doing some work twice.

I still need to understand why this results in some `Ident`-s rather than `Select`-s appearing in typed trees in `CodePrinterTest` (e.g `Ident(TypeName(Int)).setSymbol(symbolOf[scala.Int])`. We should either restore the status quo, or make sure the more compact representation isn't going to break things (such as `showCode(tree, printRootPkg = true)` in one of the tests I had to change the expectation)