### PR TITLE
2% reduction in allocations up-to-typer

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5736,7 +5736,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         if (tree1.tpe eq null)
           return setError(tree)
 
-        tree1 modifyType (pluginsTyped(_, this, tree1, mode, ptPlugins))
+        tree1 setType pluginsTyped(tree1.tpe, this, tree1, mode, ptPlugins)
 
         val result =
           if (tree1.isEmpty) tree1

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -553,7 +553,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
      *  (illegal type applications in pre will be skipped -- that's why typedSelect wraps the resulting tree in a TreeWithDeferredChecks)
      *  @return modified tree and new prefix type
      */
-    private def makeAccessible(tree: Tree, sym: Symbol, pre: Type, site: Tree): (Tree, Type) =
+    private def makeAccessible(tree: Tree, sym: Symbol, pre: Type, site: Tree): Any /*Type | (Tree, Type)*/ =
       if (!unit.isJava && context.isInPackageObject(sym, pre.typeSymbol)) {
         if (pre.typeSymbol == ScalaPackageClass && sym.isTerm) {
           // short cut some aliases. It seems pattern matching needs this
@@ -590,7 +590,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         }
         (checkAccessible(tree1, sym, qual.tpe, qual), qual.tpe)
       } else {
-        (checkAccessible(tree, sym, pre, site), pre)
+        checkAccessible(tree, sym, pre, site)
       }
 
     /** Post-process an identifier or selection node, performing the following:
@@ -5079,14 +5079,19 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               case Select(_, _) => treeCopy.Select(tree, qual, name)
               case SelectFromTypeTree(_, _) => treeCopy.SelectFromTypeTree(tree, qual, name)
             }
-            val (result, accessibleError) = silent(_.makeAccessible(tree1, sym, qual.tpe, qual)) match {
+            val pre = qual.tpe
+            var accessibleError: AccessTypeError = null
+            val result = silent(_.makeAccessible(tree1, sym, pre, qual)) match {
               case SilentTypeError(err: AccessTypeError) =>
-                (tree1, Some(err))
+                accessibleError = err
+                tree1
               case SilentTypeError(err) =>
                 SelectWithUnderlyingError(tree, err)
                 return tree
-              case SilentResultValue((qual, pre)) =>
-                (stabilize(qual, pre, mode, pt), None)
+              case SilentResultValue((qual: Tree, pre1: Type)) =>
+                stabilize(qual, pre1, mode, pt)
+              case SilentResultValue(qual: Tree) =>
+                stabilize(qual, pre, mode, pt)
             }
 
             result match {
@@ -5100,7 +5105,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                     qual // you only get to see the wrapped tree after running this check :-p
                   }) setType qual.tpe setPos qual.pos,
                   name)
-              case _ if accessibleError.isDefined =>
+              case _ if accessibleError != null =>
                 // don't adapt constructor, scala/bug#6074
                 val qual1 = if (name == nme.CONSTRUCTOR) qual
                             else adaptToMemberWithArgs(tree, qual, name, mode, reportAmbiguous = false, saveErrors = false)
@@ -5109,7 +5114,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 else
                   // before failing due to access, try a dynamic call.
                   asDynamicCall getOrElse {
-                    context.issue(accessibleError.get)
+                    context.issue(accessibleError)
                     setError(tree)
                   }
               case _ =>
@@ -5217,7 +5222,15 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 val pos = tree.pos
                 Select(atPos(pos.focusStart)(qual), name).setPos(pos)
               }
-              val (tree2, pre2) = makeAccessible(tree1, sym, pre1, qual)
+              var tree2: Tree = null
+              var pre2: Type = pre1
+              makeAccessible(tree1, sym, pre1, qual) match {
+                case (t: Tree, tp: Type) =>
+                  tree2 = t
+                  pre2 = tp
+                case t: Tree =>
+                  tree2 = t
+              }
             // scala/bug#5967 Important to replace param type A* with Seq[A] when seen from from a reference, to avoid
             //         inference errors in pattern matching.
               stabilize(tree2, pre2, mode, pt) modifyType dropIllegalStarTypes


### PR DESCRIPTION
```
[info] Benchmark                                                    (corpusPath)  (corpusVersion)         (extraArgs)  (resident)                (scalaVersion)  (source)    Mode  Cnt         Score          Error   Units
[info] HotScalacBenchmark.compile                                      ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-9bf24532-SNAPSHOT    scalap  sample  385       263.295 ±        1.352   ms/op
[info] HotScalacBenchmark.compile:compile·p0.00                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-9bf24532-SNAPSHOT    scalap  sample            253.493                  ms/op
[info] HotScalacBenchmark.compile:compile·p0.50                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-9bf24532-SNAPSHOT    scalap  sample            261.095                  ms/op
[info] HotScalacBenchmark.compile:compile·p0.90                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-9bf24532-SNAPSHOT    scalap  sample            274.203                  ms/op
[info] HotScalacBenchmark.compile:compile·p0.95                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-9bf24532-SNAPSHOT    scalap  sample            278.764                  ms/op
[info] HotScalacBenchmark.compile:compile·p0.99                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-9bf24532-SNAPSHOT    scalap  sample            295.615                  ms/op
[info] HotScalacBenchmark.compile:compile·p0.999                       ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-9bf24532-SNAPSHOT    scalap  sample            315.621                  ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999                      ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-9bf24532-SNAPSHOT    scalap  sample            315.621                  ms/op
[info] HotScalacBenchmark.compile:compile·p1.00                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-9bf24532-SNAPSHOT    scalap  sample            315.621                  ms/op
[info] HotScalacBenchmark.compile:·gc.alloc.rate                       ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-9bf24532-SNAPSHOT    scalap  sample   10       328.897 ±        4.318  MB/sec
[info] HotScalacBenchmark.compile:·gc.alloc.rate.norm                  ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-9bf24532-SNAPSHOT    scalap  sample   10  95369293.852 ±   233201.890    B/op
[info] HotScalacBenchmark.compile:·gc.churn.PS_Eden_Space              ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-9bf24532-SNAPSHOT    scalap  sample   10       327.420 ±       35.664  MB/sec
[info] HotScalacBenchmark.compile:·gc.churn.PS_Eden_Space.norm         ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-9bf24532-SNAPSHOT    scalap  sample   10  94945357.366 ± 10369159.131    B/op
[info] HotScalacBenchmark.compile:·gc.churn.PS_Survivor_Space          ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-9bf24532-SNAPSHOT    scalap  sample   10         1.959 ±        0.703  MB/sec
[info] HotScalacBenchmark.compile:·gc.churn.PS_Survivor_Space.norm     ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-9bf24532-SNAPSHOT    scalap  sample   10    568047.885 ±   203070.445    B/op
[info] HotScalacBenchmark.compile:·gc.count                            ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-9bf24532-SNAPSHOT    scalap  sample   10        58.000                 counts
[info] HotScalacBenchmark.compile:·gc.time                             ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-9bf24532-SNAPSHOT    scalap  sample   10       456.000                     ms
[success] Total time: 163 s, completed 13/08/2019 2:00:33 PM


info] Benchmark                                                    (corpusPath)  (corpusVersion)         (extraArgs)  (resident)               (scalaVersion)  (source)    Mode  Cnt         Score         Error   Units
[info] HotScalacBenchmark.compile                                      ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample  396       254.755 ±       1.204   ms/op
[info] HotScalacBenchmark.compile:compile·p0.00                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample            245.629                 ms/op
[info] HotScalacBenchmark.compile:compile·p0.50                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample            252.969                 ms/op
[info] HotScalacBenchmark.compile:compile·p0.90                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample            265.080                 ms/op
[info] HotScalacBenchmark.compile:compile·p0.95                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample            270.533                 ms/op
[info] HotScalacBenchmark.compile:compile·p0.99                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample            283.116                 ms/op
[info] HotScalacBenchmark.compile:compile·p0.999                       ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample            285.213                 ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999                      ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample            285.213                 ms/op
[info] HotScalacBenchmark.compile:compile·p1.00                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample            285.213                 ms/op
[info] HotScalacBenchmark.compile:·gc.alloc.rate                       ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample   10       345.853 ±       9.161  MB/sec
[info] HotScalacBenchmark.compile:·gc.alloc.rate.norm                  ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample   10  97047450.089 ±  195303.269    B/op
[info] HotScalacBenchmark.compile:·gc.churn.PS_Eden_Space              ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample   10       346.401 ±      22.891  MB/sec
[info] HotScalacBenchmark.compile:·gc.churn.PS_Eden_Space.norm         ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample   10  97209509.657 ± 6267978.531    B/op
[info] HotScalacBenchmark.compile:·gc.churn.PS_Survivor_Space          ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample   10         1.770 ±       1.072  MB/sec
[info] HotScalacBenchmark.compile:·gc.churn.PS_Survivor_Space.norm     ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample   10    494981.376 ±  294960.049    B/op
[info] HotScalacBenchmark.compile:·gc.count                            ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample   10        61.000                counts
[info] HotScalacBenchmark.compile:·gc.time                             ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample   10       490.000                    ms

```