### PR TITLE
Enable -Xlog-implicits by default for whitebox macro exceptions

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -868,7 +868,10 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
               case ex: AbortMacroException => MacroGeneratedAbort(expandee, ex)
               case ex: ControlThrowable => throw ex
               case ex: TypeError => MacroGeneratedTypeError(expandee, ex)
-              case NonFatal(_) => MacroGeneratedException(expandee, realex)
+              case NonFatal(_) =>
+                if (typer.context.isSearchingForImplicitParam)
+                  typer.context.openImplicits
+                MacroGeneratedException(expandee, realex)
               case fatal => throw fatal
             }
         } finally {


### PR DESCRIPTION
```
scala> import reflect.macros._, language.experimental.macros; class C1; implicit def c1: C1 = macro c1Impl; def c1Impl(c: whitebox.Context) = {import c.universe._; throw null}
import reflect.macros._
import language.experimental.macros
defined class C1
defined term macro c1: C1
c1Impl: (c: scala.reflect.macros.whitebox.Context)Nothing

scala> implicitly[C1]
<console>:18: c1 is not a valid implicit value for C1 because:
exception typechecking implicit candidate (a whitebox macro): exception during macro expansion:
java.lang.NullPointerException
	at .c1Impl(<console>:11)

       implicitly[C1]
                 ^
<console>:18: this.<c1: error> is not a valid implicit value for C1 because:
exception typechecking implicit candidate (a whitebox macro): exception during macro expansion:
java.lang.NullPointerException
	at .c1Impl(<console>:11)

       implicitly[C1]
                 ^
<console>:18: error: could not find implicit value for parameter e: C1
       implicitly[C1]
                 ^

scala> :quit
```