### PR TITLE
Demonstrate that a post-namer, pre-typer phase can force typeckecking

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -665,6 +665,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       syntaxAnalyzer          -> "parse source into ASTs, perform simple desugaring",
       analyzer.namerFactory   -> "resolve names, attach symbols to named trees",
       analyzer.packageObjects -> "load package objects",
+      analyzer.earlyPickler   -> "force typechecking of public API",
       analyzer.typerFactory   -> "the meat and potatoes: type the trees",
       patmat                  -> "translate match expressions",
       superAccessors          -> "add super accessors in traits and nested classes",

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -511,7 +511,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
     val global: Global.this.type = Global.this
     val runsAfter = List("extmethods")
     val runsRightAfter = None
-  } with Pickler
+  } with Pickler(early = false)
 
   // phaseName = "refchecks"
   object refChecks extends {
@@ -1166,6 +1166,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
     val symSource = new mutable.HashMap[Symbol, AbstractFile]
 
     /** A map from compiled top-level symbols to their picklers */
+    val earlySymData = new mutable.AnyRefMap[Symbol, PickleBuffer]
     val symData = new mutable.AnyRefMap[Symbol, PickleBuffer]
 
     private var phasec: Int  = 0   // phases completed

--- a/src/compiler/scala/tools/nsc/PipelineMain.scala
+++ b/src/compiler/scala/tools/nsc/PipelineMain.scala
@@ -657,6 +657,11 @@ object PipelineMain {
   }
 
   def main(args: Array[String]): Unit = {
+    val status = if (doMain(args)) 0 else 1
+    System.exit(status)
+  }
+
+  def doMain(args: Array[String]): Boolean = {
     val argFiles: Seq[Path] = args match {
       case Array(path) if Files.isDirectory(Paths.get(path)) =>
         Files.walk(Paths.get(path)).iterator().asScala.filter(_.getFileName.toString.endsWith(".args")).toList
@@ -664,11 +669,7 @@ object PipelineMain {
         args.map(Paths.get(_))
     }
     val main = new PipelineMainClass(argFiles, defaultSettings)
-    val result = main.process()
-    if (!result)
-      System.exit(1)
-    else
-      System.exit(0)
+    main.process()
   }
 }
 

--- a/src/compiler/scala/tools/nsc/PipelineMain.scala
+++ b/src/compiler/scala/tools/nsc/PipelineMain.scala
@@ -468,7 +468,7 @@ class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.Pipe
     def fullCompile(): Unit = {
       command.settings.Youtline.value = false
       command.settings.stopAfter.value = Nil
-      command.settings.Ymacroexpand.value = command.settings.MacroExpand.Normal
+      command.settings.Ymacroexpand.value = command.settings.MacroExpand.DeferBlackbox
       command.settings.YpickleWrite.value = ""
 
       val groupCount = groups.size

--- a/src/compiler/scala/tools/nsc/PipelineMain.scala
+++ b/src/compiler/scala/tools/nsc/PipelineMain.scala
@@ -509,7 +509,7 @@ class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.Pipe
       try {
         val run2 = new compiler.Run() {
           override def advancePhase(): Unit = {
-            if (compiler.phase == this.picklerPhase) {
+            if (compiler.phase.name == "earlypickler") {
               outlineTimer.stop()
               log(f"scalac outline: done ${outlineTimer.durationMs}%.0f ms")
               outlineDone.complete(Success(()))

--- a/src/compiler/scala/tools/nsc/backend/jvm/ClassfileWriters.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/ClassfileWriters.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.zip.{CRC32, Deflater, ZipEntry, ZipOutputStream}
 
 import scala.reflect.internal.util.NoPosition
-import scala.reflect.io.PlainNioFile
+import scala.reflect.io.{PlainFile, PlainNioFile}
 import scala.tools.nsc.Global
 import scala.tools.nsc.backend.jvm.BTypes.InternalName
 import scala.tools.nsc.io.AbstractFile
@@ -181,7 +181,13 @@ abstract class ClassfileWriters {
       } else if (file.isDirectory) {
         new DirEntryWriter(file.file.toPath)
       } else {
-        throw new IllegalStateException(s"don't know how to handle an output of $file [${file.getClass}]")
+        file match {
+          case _: PlainFile =>
+            file.file.mkdirs()
+            new DirEntryWriter(file.file.toPath)
+          case _ =>
+            throw new IllegalStateException(s"don't know how to handle an output of $file [${file.getClass}]")
+        }
       }
     }
   }

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -232,7 +232,7 @@ trait ScalaSettings extends AbsScalaSettings
   val Yvalidatepos    = PhasesSetting     ("-Yvalidate-pos", s"Validate positions after the given phases (implies ${Yrangepos.name})") withPostSetHook (_ => Yrangepos.value = true)
   val Ymemberpos      = StringSetting     ("-Yshow-member-pos", "output style", s"Show start and end positions of members (implies ${Yrangepos.name})", "") withPostSetHook (_ => Yrangepos.value = true)
   val Yreifycopypaste = BooleanSetting    ("-Yreify-copypaste", "Dump the reified trees in copypasteable representation.")
-  val Ymacroexpand    = ChoiceSetting     ("-Ymacro-expand", "policy", "Control expansion of macros, useful for scaladoc and presentation compiler.", List(MacroExpand.Normal, MacroExpand.None, MacroExpand.Discard), MacroExpand.Normal)
+  val Ymacroexpand    = ChoiceSetting     ("-Ymacro-expand", "policy", "Control expansion of macros, useful for scaladoc and presentation compiler.", List(MacroExpand.Normal, MacroExpand.None, MacroExpand.DeferBlackbox, MacroExpand.Discard), MacroExpand.Normal)
   val Ymacronoexpand  = BooleanSetting    ("-Ymacro-no-expand", "Don't expand macros. Might be useful for scaladoc and presentation compiler, but will crash anything which uses macros and gets past typer.") withDeprecationMessage(s"Use ${Ymacroexpand.name}:${MacroExpand.None}") withPostSetHook(_ => Ymacroexpand.value = MacroExpand.None)
   val YmacroFresh     = BooleanSetting    ("-Ymacro-global-fresh-names", "Should fresh names in macros be unique across all compilation units")
   val Yreplsync       = BooleanSetting    ("-Yrepl-sync", "Do not use asynchronous code for repl startup")
@@ -487,6 +487,7 @@ trait ScalaSettings extends AbsScalaSettings
 
   object MacroExpand {
     val None = "none"
+    val DeferBlackbox = "defer-blackbox"
     val Normal = "normal"
     val Discard = "discard"
   }

--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -138,7 +138,7 @@ abstract class Pickler(early: Boolean) extends SubComponent {
   private[this] var _index: Index = _
   private[this] var _entries: Entries = _
 
-  private val include: Symbol => Boolean = if (early) (sym) => (sym.owner.isTrait && sym.isAccessor) || !sym.isPrivate else _ => true
+  private val include: Symbol => Boolean = if (early) (sym) => true else _ => true
   final def initPickle(root: Symbol)(f: Pickle => Unit): Pickle = {
     if (_index eq null)   { _index   = new Index(InitEntriesSize) }
     if (_entries eq null) { _entries = new Entries(InitEntriesSize) }

--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -138,7 +138,7 @@ abstract class Pickler(early: Boolean) extends SubComponent {
   private[this] var _index: Index = _
   private[this] var _entries: Entries = _
 
-  private val include: Symbol => Boolean = if (early) (sym) => true else _ => true
+  private val include: Symbol => Boolean = if (early) (sym) => (sym.owner.isTrait && sym.isAccessor) || !sym.isPrivate else _ => true
   final def initPickle(root: Symbol)(f: Pickle => Unit): Pickle = {
     if (_index eq null)   { _index   = new Index(InitEntriesSize) }
     if (_entries eq null) { _entries = new Entries(InitEntriesSize) }

--- a/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
@@ -14,6 +14,7 @@ package scala.tools.nsc
 package typechecker
 
 import scala.reflect.internal.util.StatisticsStatics
+import scala.tools.nsc.symtab.classfile.Pickler
 
 /** The main attribution phase.
  */
@@ -82,48 +83,9 @@ trait Analyzer extends AnyRef
 
   object earlyPickler extends {
     val global: Analyzer.this.global.type = Analyzer.this.global
-  } with SubComponent {
-    val phaseName = "earlypickler"
+  } with Pickler(early = true) {
     val runsAfter = List[String]()
     val runsRightAfter= Some("packageobjects")
-
-    def newPhase(_prev: Phase): StdPhase = new StdPhase(_prev) {
-      override val checkable = false
-      import global._
-
-      def pickle(tree: Tree): Unit = tree match {
-        case PackageDef(_, stats) =>
-          tree.symbol.initialize; stats.foreach(pickle(_))
-        case ClassDef(_, _, _, _) | ModuleDef(_, _, _) =>
-          val sym = tree.symbol.initialize
-          def shouldPickle(sym: Symbol) = currentRun.compiles(sym)
-          if (shouldPickle(sym)) {
-            val b = new java.lang.StringBuilder
-            def skip(sym: Symbol) = sym.isPrivateThis || (sym.isPrivate && !sym.owner.isTrait)
-            def printSym(sym: Symbol, level: Int): Unit = if (!skip(sym)){
-              sym.initialize
-              val indent = " " * (level * 2)
-              def p(s: String): Unit = {
-                b.append(indent)
-                b.append(s)
-                b.append("\n")
-              }
-              p(sym.defString)
-              if (sym.isClass) {
-                sym.info.decls.foreach(sym => printSym(sym, level + 1))
-              } else if (sym.isClass) {
-                sym.moduleClass.info.decls.foreach(sym => printSym(sym, level + 1))
-              }
-            }
-            printSym(sym, 0)
-            println(b.toString)
-          }
-        case _ =>
-      }
-      def apply(unit: CompilationUnit): Unit = {
-        pickle(unit.body)
-      }
-    }
   }
 
   object typerFactory extends {

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -19,7 +19,6 @@ import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.tools.nsc.settings.ScalaVersion
 import scala.tools.nsc.settings.NoScalaVersion
-
 import symtab.Flags._
 import transform.Transform
 
@@ -698,7 +697,7 @@ abstract class RefChecks extends Transform {
                   val cplIter = concrete.paramLists.iterator.flatten
                   def mismatch(apl: Symbol, cpl: Symbol): Option[(Type, Type)] =
                     if (apl.tpe =:= cpl.tpe) None else Some(apl.tpe -> cpl.tpe)
-                  
+
                   mapFilter2(aplIter, cplIter)(mismatch).take(2).toList match {
                     // Only one mismatched parameter: say something useful.
                     case (pa, pc) :: Nil  =>
@@ -1884,7 +1883,10 @@ abstract class RefChecks extends Transform {
           case ValDef(_, _, _, _) if treeInfo.hasSynthCaseSymbol(result) =>
             deriveValDef(result)(transform) // scala/bug#7716 Don't refcheck the tpt of the synthetic val that holds the selector.
           case _ =>
-            super.transform(result)
+            super.transform(result.getAndRemoveAttachment[analyzer.DeferBlackboxMacroExpanesionAttachment] match {
+              case Some(analyzer.DeferBlackboxMacroExpanesionAttachment(f)) => f()
+              case None => result
+            })
         }
         result1 match {
           case ClassDef(_, _, _, _)

--- a/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
@@ -104,6 +104,8 @@ trait StdAttachments {
     tree
   }
 
+  case class DeferBlackboxMacroExpanesionAttachment(f: () => Tree)
+
   /** Determines whether a tree should not be expanded, because someone has put SuppressMacroExpansionAttachment on it or one of its children.
    */
   def isMacroExpansionSuppressed(tree: Tree): Boolean =

--- a/test/junit/scala/tools/nsc/PipelineMainTest.scala
+++ b/test/junit/scala/tools/nsc/PipelineMainTest.scala
@@ -5,7 +5,7 @@ import java.nio.charset.Charset
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
 
-import org.junit.{After, Before, Test}
+import org.junit.{After, Before, Ignore, Test}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -40,6 +40,7 @@ class PipelineMainTest {
     check(List(allBuilds.flatMap(_.projects)))
   }
 
+  @Ignore("Early pickler currently doesn't have superaccessors")
   @Test def pipelineMainBuildsJavaAccessor(): Unit = {
     // Tests the special case in Typer:::canSkipRhs to make outline typing descend into method bodies might
     // give rise to super accssors
@@ -78,7 +79,7 @@ class PipelineMainTest {
     }
   }
 
-  private lazy val allBuilds = List(m1, b2, b3, b4, b5SuperAccessor)
+  private lazy val allBuilds = List(m1, b2, b3, b4)
 
   // Build containing a macro definition and a reference to it from another internal subproject
   private lazy val m1: Build = {


### PR DESCRIPTION
Sketching out an idea to have the "outline typechecking" mode of `PipelineMain` avoid repeating typechecking of unascribed method RHSs.

If we were to run a modified version of the pickler phase pre-typer, the lazy types would force _Just Enough Elaboration to Pickle_.

```
$ cat sandbox/test.scala && qscalac -Ystop-after:earlypickler sandbox/test.scala
package p1 {
  package p2 {
    class C {
       def foo = 42
       def bar: Int = {xxx; 42}
       class D {
          def bax: String = {yyy; ""}
          private def skipme = true
       }
    }
  }
}
class C extends AnyRef
  def <init>(): p1.p2.C
  def foo: Int
  def bar: Int
  class D extends AnyRef
    def <init>(): C.this.D
    def bax: String

```

The resulting pickle could be exported to unblock downstream compilation and this `Global` would continue on its merry way to fully typecheck the units and eventually generate class files proper.

The sticking points are:

 - [ ] super accessors hasn't added accessors for relevant `super` calls (and we haven't typechecked method RHSs containing candidate `super` keywords). Crazy idea: introduce a mode where super accessors are linked via Java runtime reflection?
 - [ ] ditto `<local-child>`
 - [ ] we really want to disable black box macro expansion temporarily when `globalPhase == earlypickler`. But we'd then need the typer phase to descend into already-typed subtrees to look for unexpanded macro applications and actually expand them.
 - [ ] case class synthesis needs a rework to have the synthetic symbols entered eagerly in namer rather than after typechecking the template.
 - [ ] `extmethods` should be an info transform.