### PR TITLE
Clean unused temp vals in REPL wrappers and remove heuristic that ignores some imports

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -489,147 +489,151 @@ trait TypeDiagnostics {
     def inMode(context: Context, mode: Mode, tree: Tree): Tree = if (mode.typingMonoExprByValue) apply(context, tree) else tree
   }
 
-  class checkUnused(typer: Typer) {
+  object UnusedPrivates {
     val ignoreNames: Set[TermName] = Set(
       "readResolve", "readObject", "writeObject", "writeReplace"
     ).map(TermName(_))
+  }
 
-    class UnusedPrivates extends Traverser {
-      val defnTrees = ListBuffer[MemberDef]()
-      val targets   = mutable.Set[Symbol]()
-      val setVars   = mutable.Set[Symbol]()
-      val treeTypes = mutable.Set[Type]()
-      val params    = mutable.Set[Symbol]()
-      val patvars   = mutable.Set[Symbol]()
+  class UnusedPrivates extends Traverser {
+    import UnusedPrivates.ignoreNames
+    val defnTrees = ListBuffer[MemberDef]()
+    val targets   = mutable.Set[Symbol]()
+    val setVars   = mutable.Set[Symbol]()
+    val treeTypes = mutable.Set[Type]()
+    val params    = mutable.Set[Symbol]()
+    val patvars   = mutable.Set[Symbol]()
 
-      def defnSymbols = defnTrees.toList map (_.symbol)
-      def localVars   = defnSymbols filter (t => t.isLocalToBlock && t.isVar)
+    def defnSymbols = defnTrees.toList map (_.symbol)
+    def localVars   = defnSymbols filter (t => t.isLocalToBlock && t.isVar)
 
-      def qualifiesTerm(sym: Symbol) = (
-        (sym.isModule || sym.isMethod || sym.isPrivateLocal || sym.isLocalToBlock)
-          && !nme.isLocalName(sym.name)
-          && !sym.isParameter
-          && !sym.isParamAccessor       // could improve this, but it's a pain
-          && !sym.isEarlyInitialized    // lots of false positives in the way these are encoded
-          && !(sym.isGetter && sym.accessed.isEarlyInitialized)
-        )
-      def qualifiesType(sym: Symbol) = !sym.isDefinedInPackage
-      def qualifies(sym: Symbol) = (
-        (sym ne null)
-          && (sym.isTerm && qualifiesTerm(sym) || sym.isType && qualifiesType(sym))
-        )
-      def isExisting(sym: Symbol) = sym != null && sym.exists
+    def qualifiesTerm(sym: Symbol) = (
+      (sym.isModule || sym.isMethod || sym.isPrivateLocal || sym.isLocalToBlock || (sym.isPrivate && sym.owner.isInterpreterWrapper))
+        && !nme.isLocalName(sym.name)
+        && !sym.isParameter
+        && !sym.isParamAccessor       // could improve this, but it's a pain
+        && !sym.isEarlyInitialized    // lots of false positives in the way these are encoded
+        && !(sym.isGetter && sym.accessed.isEarlyInitialized)
+      )
+    def qualifiesType(sym: Symbol) = !sym.isDefinedInPackage
+    def qualifies(sym: Symbol) = (
+      (sym ne null)
+        && (sym.isTerm && qualifiesTerm(sym) || sym.isType && qualifiesType(sym))
+      )
+    def isExisting(sym: Symbol) = sym != null && sym.exists
 
-      override def traverse(t: Tree): Unit = {
-        val sym = t.symbol
-        t match {
-          case m: MemberDef if qualifies(sym) && !t.isErrorTyped =>
-            t match {
-              case ValDef(mods@_, name@_, tpt@_, rhs@_) if wasPatVarDef(t) =>
-                if (settings.warnUnusedPatVars && !atBounded(t)) patvars += sym
-              case DefDef(mods@_, name@_, tparams@_, vparamss, tpt@_, rhs@_) if !sym.isAbstract && !sym.isDeprecated && !sym.isMacro =>
-                if (sym.isPrimaryConstructor)
-                  for (cpa <- sym.owner.constrParamAccessors if cpa.isPrivateLocal) params += cpa
-                else if (sym.isSynthetic && sym.isImplicit) return
-                else if (!sym.isConstructor && rhs.symbol != Predef_???)
-                  for (vs <- vparamss) params ++= vs.map(_.symbol)
-                defnTrees += m
-              case _ =>
-                defnTrees += m
-            }
-          case CaseDef(pat, guard@_, rhs@_) if settings.warnUnusedPatVars && !t.isErrorTyped =>
-            pat.foreach {
-              case b @ Bind(n, _) if !atBounded(b) && n != nme.DEFAULT_CASE => patvars += b.symbol
-              case _ =>
-            }
-          case _: RefTree if isExisting(sym)            => targets += sym
-          case Assign(lhs, _) if isExisting(lhs.symbol) => setVars += lhs.symbol
-          case Function(ps, _) if settings.warnUnusedParams && !t.isErrorTyped => params ++=
-            ps.filterNot(p => atBounded(p) || p.symbol.isSynthetic).map(_.symbol)
-          case _                                        =>
-        }
-
-        if (t.tpe ne null) {
-          for (tp <- t.tpe) if (!treeTypes(tp)) {
-            // Include references to private/local aliases (which might otherwise refer to an enclosing class)
-            val isAlias = {
-              val td = tp.typeSymbolDirect
-              td.isAliasType && (td.isLocal || td.isPrivate)
-            }
-            // Ignore type references to an enclosing class. A reference to C must be outside C to avoid warning.
-            if (isAlias || !currentOwner.hasTransOwner(tp.typeSymbol)) tp match {
-              case NoType | NoPrefix    =>
-              case NullaryMethodType(_) =>
-              case MethodType(_, _)     =>
-              case SingleType(_, _)     =>
-              case ConstantType(Constant(k: Type)) =>
-                log(s"classOf $k referenced from $currentOwner")
-                treeTypes += k
-              case _                    =>
-                log(s"${if (isAlias) "alias " else ""}$tp referenced from $currentOwner")
-                treeTypes += tp
-            }
+    override def traverse(t: Tree): Unit = {
+      val sym = t.symbol
+      t match {
+        case m: MemberDef if qualifies(sym) && !t.isErrorTyped =>
+          t match {
+            case ValDef(mods@_, name@_, tpt@_, rhs@_) if wasPatVarDef(t) =>
+              if (settings.warnUnusedPatVars && !atBounded(t)) patvars += sym
+            case DefDef(mods@_, name@_, tparams@_, vparamss, tpt@_, rhs@_) if !sym.isAbstract && !sym.isDeprecated && !sym.isMacro =>
+              if (sym.isPrimaryConstructor)
+                for (cpa <- sym.owner.constrParamAccessors if cpa.isPrivateLocal) params += cpa
+              else if (sym.isSynthetic && sym.isImplicit) return
+              else if (!sym.isConstructor && rhs.symbol != Predef_???)
+                for (vs <- vparamss) params ++= vs.map(_.symbol)
+              defnTrees += m
+            case _ =>
+              defnTrees += m
           }
-          // e.g. val a = new Foo ; new a.Bar ; don't let a be reported as unused.
-          for (p <- t.tpe.prefix) condOpt(p) {
-            case SingleType(_, sym) => targets += sym
+        case CaseDef(pat, guard@_, rhs@_) if settings.warnUnusedPatVars && !t.isErrorTyped =>
+          pat.foreach {
+            case b @ Bind(n, _) if !atBounded(b) && n != nme.DEFAULT_CASE => patvars += b.symbol
+            case _ =>
+          }
+        case _: RefTree if isExisting(sym)            => targets += sym
+        case Assign(lhs, _) if isExisting(lhs.symbol) => setVars += lhs.symbol
+        case Function(ps, _) if settings.warnUnusedParams && !t.isErrorTyped => params ++=
+          ps.filterNot(p => atBounded(p) || p.symbol.isSynthetic).map(_.symbol)
+        case _                                        =>
+      }
+
+      if (t.tpe ne null) {
+        for (tp <- t.tpe) if (!treeTypes(tp)) {
+          // Include references to private/local aliases (which might otherwise refer to an enclosing class)
+          val isAlias = {
+            val td = tp.typeSymbolDirect
+            td.isAliasType && (td.isLocal || td.isPrivate)
+          }
+          // Ignore type references to an enclosing class. A reference to C must be outside C to avoid warning.
+          if (isAlias || !currentOwner.hasTransOwner(tp.typeSymbol)) tp match {
+            case NoType | NoPrefix    =>
+            case NullaryMethodType(_) =>
+            case MethodType(_, _)     =>
+            case SingleType(_, _)     =>
+            case ConstantType(Constant(k: Type)) =>
+              log(s"classOf $k referenced from $currentOwner")
+              treeTypes += k
+            case _                    =>
+              log(s"${if (isAlias) "alias " else ""}$tp referenced from $currentOwner")
+              treeTypes += tp
           }
         }
-        super.traverse(t)
+        // e.g. val a = new Foo ; new a.Bar ; don't let a be reported as unused.
+        for (p <- t.tpe.prefix) condOpt(p) {
+          case SingleType(_, sym) => targets += sym
+        }
       }
-      def isUnusedType(m: Symbol): Boolean = (
-        m.isType
-          && !m.isTypeParameterOrSkolem // would be nice to improve this
-          && (m.isPrivate || m.isLocalToBlock)
-          && !(treeTypes.exists(_.exists(_.typeSymbolDirect == m)))
-        )
-      def isSyntheticWarnable(sym: Symbol) = (
-        sym.isDefaultGetter
-        )
-      def isUnusedTerm(m: Symbol): Boolean = (
-        m.isTerm
-          && (!m.isSynthetic || isSyntheticWarnable(m))
-          && ((m.isPrivate && !(m.isConstructor && m.owner.isAbstract)) || m.isLocalToBlock)
-          && !targets(m)
-          && !(m.name == nme.WILDCARD)              // e.g. val _ = foo
-          && (m.isValueParameter || !ignoreNames(m.name.toTermName)) // serialization methods
-          && !isConstantType(m.info.resultType)     // subject to constant inlining
-          && !treeTypes.exists(_ contains m)        // e.g. val a = new Foo ; new a.Bar
-        )
-      def isUnusedParam(m: Symbol): Boolean = (
-        isUnusedTerm(m)
-          && !m.isDeprecated
-          && !m.owner.isDefaultGetter
-          && !(m.isParamAccessor && (
-          m.owner.isImplicit ||
-            targets.exists(s => s.isParameter
-              && s.name == m.name && s.owner.isConstructor && s.owner.owner == m.owner) // exclude ctor params
-          ))
-        )
-      def sympos(s: Symbol): Int =
-        if (s.pos.isDefined) s.pos.point else if (s.isTerm) s.asTerm.referenced.pos.point else -1
-      def treepos(t: Tree): Int =
-        if (t.pos.isDefined) t.pos.point else sympos(t.symbol)
-
-      def unusedTypes = defnTrees.toList.filter(t => isUnusedType(t.symbol)).sortBy(treepos)
-      def unusedTerms = {
-        val all = defnTrees.toList.filter(v => isUnusedTerm(v.symbol))
-
-        // is this a getter-setter pair? and why is this a difficult question for traits?
-        def sameReference(g: Symbol, s: Symbol) =
-          if (g.accessed.exists && s.accessed.exists) g.accessed == s.accessed
-          else g.owner == s.owner && g.setterName == s.name         //sympos(g) == sympos(s)
-
-        // filter out setters if already warning for getter.
-        val clean = all.filterNot(v => v.symbol.isSetter && all.exists(g => g.symbol.isGetter && sameReference(g.symbol, v.symbol)))
-        clean.sortBy(treepos)
-      }
-      // local vars which are never set, except those already returned in unused
-      def unsetVars = localVars.filter(v => !setVars(v) && !isUnusedTerm(v)).sortBy(sympos)
-      def unusedParams = params.toList.filter(isUnusedParam).sortBy(sympos)
-      def inDefinedAt(p: Symbol) = p.owner.isMethod && p.owner.name == nme.isDefinedAt && p.owner.owner.isAnonymousFunction
-      def unusedPatVars = patvars.toList.filter(p => isUnusedTerm(p) && !inDefinedAt(p)).sortBy(sympos)
+      super.traverse(t)
     }
+    def isUnusedType(m: Symbol): Boolean = (
+      m.isType
+        && !m.isTypeParameterOrSkolem // would be nice to improve this
+        && (m.isPrivate || m.isLocalToBlock)
+        && !(treeTypes.exists(_.exists(_.typeSymbolDirect == m)))
+      )
+    def isSyntheticWarnable(sym: Symbol) = (
+      sym.isDefaultGetter
+      )
+    def isUnusedTerm(m: Symbol): Boolean = (
+      m.isTerm
+        && (!m.isSynthetic || isSyntheticWarnable(m))
+        && ((m.isPrivate && !(m.isConstructor && m.owner.isAbstract)) || m.isLocalToBlock)
+        && !targets(m)
+        && !(m.name == nme.WILDCARD)              // e.g. val _ = foo
+        && (m.isValueParameter || !ignoreNames(m.name.toTermName)) // serialization methods
+        && !isConstantType(m.info.resultType)     // subject to constant inlining
+        && !treeTypes.exists(_ contains m)        // e.g. val a = new Foo ; new a.Bar
+      )
+    def isUnusedParam(m: Symbol): Boolean = (
+      isUnusedTerm(m)
+        && !m.isDeprecated
+        && !m.owner.isDefaultGetter
+        && !(m.isParamAccessor && (
+        m.owner.isImplicit ||
+          targets.exists(s => s.isParameter
+            && s.name == m.name && s.owner.isConstructor && s.owner.owner == m.owner) // exclude ctor params
+        ))
+      )
+    def sympos(s: Symbol): Int =
+      if (s.pos.isDefined) s.pos.point else if (s.isTerm) s.asTerm.referenced.pos.point else -1
+    def treepos(t: Tree): Int =
+      if (t.pos.isDefined) t.pos.point else sympos(t.symbol)
+
+    def unusedTypes = defnTrees.toList.filter(t => isUnusedType(t.symbol)).sortBy(treepos)
+    def unusedTerms = {
+      val all = defnTrees.toList.filter(v => isUnusedTerm(v.symbol))
+
+      // is this a getter-setter pair? and why is this a difficult question for traits?
+      def sameReference(g: Symbol, s: Symbol) =
+        if (g.accessed.exists && s.accessed.exists) g.accessed == s.accessed
+        else g.owner == s.owner && g.setterName == s.name         //sympos(g) == sympos(s)
+
+      // filter out setters if already warning for getter.
+      val clean = all.filterNot(v => v.symbol.isSetter && all.exists(g => g.symbol.isGetter && sameReference(g.symbol, v.symbol)))
+      clean.sortBy(treepos)
+    }
+    // local vars which are never set, except those already returned in unused
+    def unsetVars = localVars.filter(v => !setVars(v) && !isUnusedTerm(v)).sortBy(sympos)
+    def unusedParams = params.toList.filter(isUnusedParam).sortBy(sympos)
+    def inDefinedAt(p: Symbol) = p.owner.isMethod && p.owner.name == nme.isDefinedAt && p.owner.owner.isAnonymousFunction
+    def unusedPatVars = patvars.toList.filter(p => isUnusedTerm(p) && !inDefinedAt(p)).sortBy(sympos)
+  }
+
+  class checkUnused(typer: Typer) {
 
     object skipMacroCall extends UnusedPrivates {
       override def qualifiesTerm(sym: Symbol): Boolean =

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -244,7 +244,8 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
   protected def newCompiler(settings: Settings, reporter: reporters.Reporter): ReplGlobal = {
     settings.outputDirs setSingleOutput replOutput.dir
     settings.exposeEmptyPackage.value = true
-    new Global(settings, reporter) with ReplGlobal { override def toString: String = "<global>" }
+    val g = new Global(settings, reporter) with ReplGlobal { override def toString: String = "<global>" }
+    g
   }
 
   /**

--- a/src/repl/scala/tools/nsc/interpreter/Imports.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Imports.scala
@@ -121,24 +121,6 @@ trait Imports {
         // Single symbol imports might be implicits! See bug #1752.  Rather than
         // try to finesse this, we will mimic all imports for now.
         def keepHandler(handler: MemberHandler) = handler match {
-          // While defining classes in class based mode - implicits are not needed.
-          // JZ: Not true! This originated in https://github.com/apache/spark/commit/b63d3b28f0ce4a7eab0b1bc673312bc3e7c396dd
-          //     to fix https://issues.apache.org/jira/browse/SPARK-5150 and https://issues.apache.org/jira/browse/SPARK-2576
-          //     but changes semantics as reported https://issues.apache.org/jira/browse/SPARK-5150 or by running
-          //     run/t6320 in -Yrepl-class-based mode.
-          //
-          //     Instead, we should remove the special case below, allowing implicits to be imports, but
-          //     prune unused temp vals after typechecking with a custom REPL phase.
-          //
-          //     scala> class TestClass() { def testMethod = 3 }; val t = new TestClass
-          //     scala> import t.testMethod
-          //     scala> case class TestCaseClass(value: Int)
-          //
-          //         // Remove this unused val with a post-typer REPL phase.
-          //         val $line4$read: $line4.$read.INSTANCE.type = $line4.$read.INSTANCE;
-          //         import $line4$read.$iw.t;
-          //         import t.testMethod;
-          case h: ImportHandler if isClassBased && definesClass => h.importedNames.exists(x => wanted.contains(x))
           case _: ImportHandler     => true
           case x if generousImports => x.definesImplicit || (x.definedNames exists (d => wanted.exists(w => d.startsWith(w))))
           case x                    => x.definesImplicit || (x.definedNames exists wanted)
@@ -219,7 +201,7 @@ trait Imports {
               case _ =>
                 val valName = s"${req.lineRep.packageName}${req.lineRep.readName}"
                 if (!tempValLines.contains(req.lineRep.lineId)) {
-                  code.append(s"val $valName: ${objName}.type = $objName; ")
+                  code.append(s"private val $valName: ${objName}.type = $objName; ")
                   tempValLines += req.lineRep.lineId
                 }
                 code.append(s"import ${valName}${req.accessPath}.`${sym.name}`\n")

--- a/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
@@ -14,6 +14,7 @@ package scala.tools.nsc
 package interpreter
 
 import scala.tools.nsc.classpath.{AggregateClassPath, ClassPathFactory}
+import scala.tools.nsc.transform.Transform
 import scala.tools.nsc.util.ClassPath
 import typechecker.Analyzer
 
@@ -21,6 +22,7 @@ import typechecker.Analyzer
  *  functionality for the repl.  It doesn't do much yet.
  */
 trait ReplGlobal extends Global {
+  self =>
   // This exists mostly because using the reporter too early leads to deadlock.
   private def echo(msg: String) { Console println msg }
 
@@ -37,6 +39,35 @@ trait ReplGlobal extends Global {
       macroLogVerbose("macro classloader: initializing from a REPL classloader: %s".format(global.classPath.asURLs))
       val virtualDirectory = globalSettings.outputDirs.getSingleOutput.get
       new util.AbstractFileClassLoader(virtualDirectory, loader) {}
+    }
+  }
+
+  override protected def computeInternalPhases(): Unit = {
+    super.computeInternalPhases()
+    addToPhasesSet(wrapperCleanup, "Remove usused values from import wrappers to avoid unwanted capture of non-serializable objects")
+  }
+
+  private object wrapperCleanup extends Transform {
+    override val global: self.type = self
+    override val phaseName: String = "wrapper-cleanup"
+    /** Names of phases that must run before this phase. */
+    override val runsAfter: List[String] = List("refchecks")
+    /** Name of the phase that this phase must follow immediately. */
+    override val runsRightAfter: Option[String] = None
+    override protected def newTransformer(unit: CompilationUnit): Transformer = new WrapperCleanupTransformer(unit)
+    class WrapperCleanupTransformer(unit: CompilationUnit) extends Transformer {
+      val unusedPrivates = new analyzer.UnusedPrivates()
+      unusedPrivates.traverse(unit.body)
+      val unusedSet = unusedPrivates.unusedTerms.iterator.flatMap(tree => List(tree.symbol, tree.symbol.accessedOrSelf)).toSet
+      override def transformTemplate(tree: Template): Template = {
+        val (unused, used) = tree.body.partition (t => unusedSet(t.symbol))
+        if (unused.isEmpty ) tree
+        else {
+          val decls = tree.symbol.info.decls
+          unused.foreach(tree => decls.unlink(tree.symbol))
+          deriveTemplate(tree)(_ => used)
+        }
+      }
     }
   }
 

--- a/test/files/run/repl-class-based-implicit-import.check
+++ b/test/files/run/repl-class-based-implicit-import.check
@@ -1,0 +1,21 @@
+
+scala> def showInt(implicit x: Int) = println(x)
+showInt: (implicit x: Int)Unit
+
+scala> object IntHolder { implicit val myInt = 5 }
+defined object IntHolder
+
+scala> import IntHolder.myInt
+import IntHolder.myInt
+
+scala> showInt
+5
+
+scala> class A; showInt
+5
+defined class A
+
+scala> class B { showInt }
+defined class B
+
+scala> :quit

--- a/test/files/run/repl-class-based-implicit-import.scala
+++ b/test/files/run/repl-class-based-implicit-import.scala
@@ -1,0 +1,20 @@
+import scala.tools.nsc.Settings
+import scala.tools.partest.ReplTest
+
+// https://issues.apache.org/jira/browse/SPARK-5150
+object Test extends ReplTest {
+
+  override def transformSettings(s: Settings) = {
+    s.Yreplclassbased.value = true
+    s
+  }
+
+  def code = """
+    |def showInt(implicit x: Int) = println(x)
+    |object IntHolder { implicit val myInt = 5 }
+    |import IntHolder.myInt
+    |showInt
+    |class A; showInt
+    |class B { showInt }
+    |""".stripMargin
+}

--- a/test/files/run/repl-serialization.check
+++ b/test/files/run/repl-serialization.check
@@ -11,6 +11,9 @@ defined class D
 z: Int = 0
 zz: Int = 0
 defined object O
+defined class TestClass
+t: TestClass = TestClass
+import t._
 defined class A
 defined type alias AA
 constructing U

--- a/test/files/run/repl-serialization.scala
+++ b/test/files/run/repl-serialization.scala
@@ -14,6 +14,8 @@ object Test {
   def run(): Unit = {
     val settings = new Settings()
     settings.Yreplclassbased.value = true
+    settings.YreplMagicImport.value = true
+    //settings.Xprint.value = List("refchecks","wrapper-cleanup")
     settings.usejavacp.value = true
 
     var imain: IMain = null
@@ -30,6 +32,8 @@ object Test {
         |lazy val y = {println("  evaluating y"); 0 }
         |class D; val z = {println("  evaluating z"); 0}; val zz = {println("  evaluating zz"); 0}
         |object O extends Serializable { val apply = {println("  evaluating O"); 0} }
+        |class TestClass() { def testMethod = 3; override def toString = "TestClass" }; val t = new TestClass // not serializable
+        |import t._
         |class A(i: Int) { println("  constructing A") }
         |type AA = A
         |val u = new U()


### PR DESCRIPTION
Notice how `val $line3$read` is removed below by the `wrapper-cleanup` phase.

```
➜  scala-repl-class-based-default git:(topic/repl-class-based-default) ✗ qscala -Yrepl-class-based -Yrepl-use-magic-imports -Xprint:typer,refchecks,wrapper-cleanup
Welcome to Scala 2.12.11-20200117-034902-unknown (OpenJDK 64-Bit Server VM, Java 1.8.0-adoptopenjdk).
Type in expressions for evaluation. Or try :help.

scala> class M { def foo = 42 }; val m = new M


defined class M
m: M = M@37864b77

scala> import m._

import m._


scala> class C()
...
defined class C

scala> () => new C
[[syntax trees at end of                     typer]] // <console>
package $line15 {
  sealed class $read extends AnyRef with java.io.Serializable {
    def <init>(): $line15.$read = {
      $read.super.<init>();
      ()
    };
    private[this] val $line3$read: $line3.$read.type = $line3.$read.INSTANCE;
    <stable> <accessor> private def $line3$read: $line3.$read.type = $read.this.$line3$read;
    import $read.this.$line3$read.$iw.m;
    import scala.tools.nsc.interpreter.$u007B$u007B;
    import $read.this.$line3$read.$iw.m._;
    import scala.tools.nsc.interpreter.$u007B$u007B;
    import $line14.$read.INSTANCE.$iw.C;
    sealed class $iw extends AnyRef with java.io.Serializable {
      def <init>(): $iw = {
        $iw.super.<init>();
        ()
      };
      private[this] val res0: () => C = (() => new $line14.$read.INSTANCE.$iw.C());
      <stable> <accessor> def res0: () => C = $iw.this.res0
    };
    private[this] val $iw: $iw = new $read.this.$iw();
    <stable> <accessor> def $iw: $iw = $read.this.$iw
  };
  object $read extends scala.AnyRef with Serializable {
    def <init>(): type = {
      $read.super.<init>();
      ()
    };
    private[this] val INSTANCE: $line15.$read = new $read();
    <stable> <accessor> def INSTANCE: $line15.$read = $read.this.INSTANCE;
    <synthetic> private def readResolve(): Object = $line15.$read
  }
}

[[syntax trees at end of                 refchecks]] // <console>
package $line15 {
  sealed class $read extends AnyRef with java.io.Serializable {
    def <init>(): $line15.$read = {
      $read.super.<init>();
      ()
    };
    private[this] val $line3$read: $line3.$read.type = $line3.$read.INSTANCE;
    <stable> <accessor> private def $line3$read: $line3.$read.type = $read.this.$line3$read;
    sealed class $iw extends AnyRef with java.io.Serializable {
      def <init>(): $iw = {
        $iw.super.<init>();
        ()
      };
      private[this] val res0: () => C = (() => new $line14.$read.INSTANCE.$iw.C());
      <stable> <accessor> def res0: () => C = $iw.this.res0
    };
    private[this] val $iw: $iw = new $read.this.$iw();
    <stable> <accessor> def $iw: $iw = $read.this.$iw
  };
  object $read extends scala.AnyRef with Serializable {
    def <init>(): type = {
      $read.super.<init>();
      ()
    };
    private[this] val INSTANCE: $line15.$read = new $read();
    <stable> <accessor> def INSTANCE: $line15.$read = $read.this.INSTANCE;
    <synthetic> private def readResolve(): Object = $line15.$read
  }
}

[[syntax trees at end of           wrapper-cleanup]] // <console>
package $line15 {
  sealed class $read extends Object with java.io.Serializable {
    def <init>(): $line15.$read = {
      $read.super.<init>();
      ()
    };
    sealed class $iw extends Object with java.io.Serializable {
      def <init>(): $iw = {
        $iw.super.<init>();
        ()
      };
      private[this] val res0: () => C = {
        final <artifact> def $anonfun$res0(): C = new C();
        (() => $anonfun$res0())
      };
      <stable> <accessor> def res0(): () => C = $iw.this.res0
    };
    private[this] val $iw: $iw = new $iw();
    <stable> <accessor> def $iw(): $iw = $read.this.$iw
  };
  object $read extends Object with Serializable {
    def <init>(): type = {
      $read.super.<init>();
      ()
    };
    private[this] val INSTANCE: $line15.$read = new $line15.$read();
    <stable> <accessor> def INSTANCE(): $line15.$read = $read.this.INSTANCE;
    <synthetic> private def readResolve(): Object = $line15.$read
  }
}

res0: () => C = $Lambda$1941/196237139@ee21292

```