### PR TITLE
Rework Transformer.treeCopy extension point

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -365,6 +365,9 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.api.TypeTags.TypeTagImpl"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.api.Universe.TypeTagImpl"),
 
+    ProblemFilters.exclude[FinalMethodProblem]("scala.reflect.api.Trees#Transformer.treeCopy"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.api.Trees#Transformer.setTreeCopy"),
+
     ProblemFilters.exclude[MissingClassProblem]("scala.reflect.macros.Attachments$"),
 
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.reflect.io.ZipArchive.getDir"),

--- a/src/compiler/scala/tools/nsc/ast/Trees.scala
+++ b/src/compiler/scala/tools/nsc/ast/Trees.scala
@@ -105,8 +105,8 @@ trait Trees extends scala.reflect.internal.Trees { self: Global =>
   }
   implicit val TreeCopierTag: ClassTag[TreeCopier] = ClassTag[TreeCopier](classOf[TreeCopier])
 
-  def newStrictTreeCopier: TreeCopier = new StrictTreeCopier
-  def newLazyTreeCopier: TreeCopier = new LazyTreeCopier
+  lazy val newStrictTreeCopier: TreeCopier = new StrictTreeCopier
+  lazy val newLazyTreeCopier: TreeCopier = new LazyTreeCopier
 
   class StrictTreeCopier extends super.StrictTreeCopier with TreeCopier {
     def DocDef(tree: Tree, comment: DocComment, definition: Tree) =

--- a/src/reflect/scala/reflect/api/Trees.scala
+++ b/src/reflect/scala/reflect/api/Trees.scala
@@ -2538,7 +2538,9 @@ trait Trees { self: Universe =>
    */
   abstract class Transformer {
     /** The underlying tree copier. */
-    val treeCopy: TreeCopier = newLazyTreeCopier
+    private[this] var _treeCopy: TreeCopier = newLazyTreeCopier
+    protected final def setTreeCopy(treeCopy: TreeCopier): Unit = this._treeCopy = treeCopy
+    final def treeCopy: TreeCopier = _treeCopy
 
     /** The current owner symbol. */
     protected[scala] var currentOwner: Symbol = rootMirror.RootClass

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1532,7 +1532,7 @@ trait Trees extends api.Trees {
   }
 
   private class ShallowDuplicator(orig: Tree) extends Transformer {
-    override val treeCopy = newStrictTreeCopier
+    setTreeCopy(newStrictTreeCopier)
     override def transform(tree: Tree) =
       if (tree eq orig) super.transform(tree)
       else tree
@@ -1703,7 +1703,7 @@ trait Trees extends api.Trees {
 
   private lazy val duplicator = new Duplicator(focusPositions = true)
   private class Duplicator(focusPositions: Boolean) extends Transformer {
-    override val treeCopy = newStrictTreeCopier
+    setTreeCopy(newStrictTreeCopier)
     override def transform(t: Tree) = {
       val t1 = super.transform(t)
       if ((t1 ne t) && t1.pos.isRange && focusPositions) t1 setPos t.pos.focus
@@ -1711,7 +1711,7 @@ trait Trees extends api.Trees {
     }
   }
   object duplicateAndResetPos extends Transformer {
-    override val treeCopy = newStrictTreeCopier
+    setTreeCopy(newStrictTreeCopier)
     override def transform(t: Tree) = {
       val t1 = super.transform(t)
       if (t1 ne EmptyTree) t1.setPos(NoPosition)


### PR DESCRIPTION
Subclasses that want a strict copier now need to call
`setTreeCopy`.

The advantage of the new setup is that we avoid a virtual
call each time a tree copier is used in a transform.

I've also reused the instances of the lazy and strict tree copiers.