### PR TITLE
Compiler determinism dogfood tester

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1041,6 +1041,10 @@ lazy val junit = project.in(file("test") / "junit")
     javaOptions in Test += "-Xss1M",
     (forkOptions in Test) := (forkOptions in Test).value.withWorkingDirectory((baseDirectory in ThisBuild).value),
     (forkOptions in Test in testOnly) := (forkOptions in Test in testOnly).value.withWorkingDirectory((baseDirectory in ThisBuild).value),
+    (forkOptions in Test in run) := {
+      val existing = (forkOptions in Test in run).value
+      existing.withRunJVMOptions(existing.runJVMOptions ++ List("-Xmx2G", "-Xss1M"))
+    },
     libraryDependencies ++= Seq(junitDep, junitInterfaceDep, jolDep),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
     unmanagedSourceDirectories in Compile := Nil,

--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -169,7 +169,7 @@ abstract class Pickler extends SubComponent {
     private var ep        = 0
     private lazy val nonClassRoot = findSymbol(root.ownersIterator)(!_.isClass)
     def include(sym: Symbol) = !noPrivates || !sym.isPrivate || (sym.owner.isTrait && sym.isAccessor)
-
+    val debug = root.fullName == "scala.Symbol"
     def close(): Unit = { writeArray(); index = null; entries = null }
 
     private def isRootSym(sym: Symbol) =
@@ -209,6 +209,7 @@ abstract class Pickler extends SubComponent {
     private val reserved = mutable.BitSet()
     final def reserveEntry(sym: Symbol): Boolean = {
       if (include(sym)) {
+        if (debug) println("reserving: " + sym)
         reserved(ep) = true
         putEntry(sym)
         true
@@ -226,6 +227,7 @@ abstract class Pickler extends SubComponent {
         case Some(i) =>
           reserved.remove(i)
         case None =>
+          if (debug) println("putEntry: " + entry)
           if (ep == entries.length) {
             val entries1 = new Array[AnyRef](ep * 2)
             System.arraycopy(entries, 0, entries1, 0, ep)

--- a/test/junit/scala/tools/nsc/DeterminismTest.scala
+++ b/test/junit/scala/tools/nsc/DeterminismTest.scala
@@ -1,19 +1,13 @@
 package scala.tools.nsc
 
-import java.io.OutputStreamWriter
-import java.nio.charset.Charset
-import java.nio.file.attribute.BasicFileAttributes
-import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
-
-import javax.tools.ToolProvider
 import org.junit.Test
 
-import scala.collection.JavaConverters.seqAsJavaListConverter
 import scala.reflect.internal.util.{BatchSourceFile, SourceFile}
-import scala.tools.nsc.reporters.StoreReporter
-import FileUtils._
 
 class DeterminismTest {
+  private val tester = new DeterminismTester
+  import tester.test
+
   @Test def testLambdaLift(): Unit = {
     def code = List[SourceFile](
       source("a.scala",
@@ -301,64 +295,4 @@ class DeterminismTest {
   }
 
   def source(name: String, code: String): SourceFile = new BatchSourceFile(name, code)
-  private def test(groups: List[List[SourceFile]]): Unit = {
-    val referenceOutput = Files.createTempDirectory("reference")
-
-    def compile(output: Path, files: List[SourceFile]): Unit = {
-      val g = new Global(new Settings)
-      g.settings.usejavacp.value = true
-      g.settings.classpath.value = output.toAbsolutePath.toString
-      g.settings.outputDirs.setSingleOutput(output.toString)
-      val storeReporter = new StoreReporter
-      g.reporter = storeReporter
-      import g._
-      val r = new Run
-      // println("scalac " + files.mkString(" "))
-      r.compileSources(files)
-      Predef.assert(!storeReporter.hasErrors, storeReporter.infos.mkString("\n"))
-      files.filter(_.file.name.endsWith(".java")) match {
-        case Nil =>
-        case javaSources =>
-          def tempFileFor(s: SourceFile): Path = {
-            val f = output.resolve(s.file.name)
-            Files.write(f, new String(s.content).getBytes(Charset.defaultCharset()))
-          }
-          val options = List("-d", output.toString)
-          val javac = ToolProvider.getSystemJavaCompiler
-          assert(javac != null, "No javac from getSystemJavaCompiler. If the java on your path isn't a JDK version, but $JAVA_HOME is, launch sbt with --java-home \"$JAVA_HOME\"")
-          val fileMan = javac.getStandardFileManager(null, null, null)
-          val javaFileObjects = fileMan.getJavaFileObjects(javaSources.map(s => tempFileFor(s).toAbsolutePath.toString): _*)
-          val task = javac.getTask(new OutputStreamWriter(System.out), fileMan, null, options.asJava, Nil.asJava, javaFileObjects)
-          val result = task.call()
-          Predef.assert(result)
-      }
-    }
-
-    for (group <- groups.init) {
-      compile(referenceOutput, group)
-    }
-    compile(referenceOutput, groups.last)
-
-    class CopyVisitor(src: Path, dest: Path) extends SimpleFileVisitor[Path] {
-      override def preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult = {
-        Files.createDirectories(dest.resolve(src.relativize(dir)))
-        super.preVisitDirectory(dir, attrs)
-      }
-      override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
-        Files.copy(file, dest.resolve(src.relativize(file)))
-        super.visitFile(file, attrs)
-      }
-    }
-    for (permutation <- permutationsWithSubsets(groups.last)) {
-      val recompileOutput = Files.createTempDirectory("recompileOutput")
-      copyRecursive(referenceOutput, recompileOutput)
-      compile(recompileOutput, permutation)
-      assertDirectorySame(referenceOutput, recompileOutput, permutation.toString)
-      deleteRecursive(recompileOutput)
-    }
-    deleteRecursive(referenceOutput)
-
-  }
-  def permutationsWithSubsets[A](as: List[A]): List[List[A]] =
-    as.permutations.toList.flatMap(_.inits.filter(_.nonEmpty)).distinct
 }

--- a/test/junit/scala/tools/nsc/DeterminismTester.scala
+++ b/test/junit/scala/tools/nsc/DeterminismTester.scala
@@ -1,0 +1,94 @@
+package scala.tools.nsc
+
+import java.io.OutputStreamWriter
+import java.nio.charset.Charset
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
+
+import javax.tools.ToolProvider
+
+import scala.collection.JavaConverters.seqAsJavaListConverter
+import scala.reflect.internal.util.SourceFile
+import scala.reflect.io.AbstractFile
+import scala.tools.nsc.FileUtils._
+import scala.tools.nsc.reporters.StoreReporter
+import scala.reflect.internal.util.BatchSourceFile
+
+object DeterminismTester extends DeterminismTester
+
+class DeterminismTester {
+  def main(args: Array[String]): Unit = {
+    val separator = args.indexOf("--")
+    val (scalacOpts, sourceFilesPaths) = args.indexOf("--") match {
+      case -1 => (Nil, args.toList)
+      case i =>
+        val tuple = args.toList.splitAt(separator)
+        (tuple._1, tuple._2.drop(1))
+    }
+    test(scalacOpts, sourceFilesPaths.map(path => new BatchSourceFile(AbstractFile.getFile(path))) :: Nil)
+  }
+
+  def test(groups: List[List[SourceFile]]): Unit = test(Nil, groups)
+  def test(scalacOptions: List[String], groups: List[List[SourceFile]]): Unit = {
+    val referenceOutput = Files.createTempDirectory("reference")
+
+    def compile(output: Path, files: List[SourceFile]): Unit = {
+      val g = new Global(new Settings)
+      g.settings.usejavacp.value = true
+      g.settings.classpath.value = output.toAbsolutePath.toString
+      g.settings.outputDirs.setSingleOutput(output.toString)
+      g.settings.processArguments(scalacOptions, true)
+      val storeReporter = new StoreReporter
+      g.reporter = storeReporter
+      import g._
+      val r = new Run
+      // println("scalac " + files.mkString(" "))
+      r.compileSources(files)
+      Predef.assert(!storeReporter.hasErrors, storeReporter.infos.mkString("\n"))
+      files.filter(_.file.name.endsWith(".java")) match {
+        case Nil =>
+        case javaSources =>
+          def tempFileFor(s: SourceFile): Path = {
+            val f = output.resolve(s.file.name)
+            Files.write(f, new String(s.content).getBytes(Charset.defaultCharset()))
+          }
+          val options = List("-d", output.toString)
+          val javac = ToolProvider.getSystemJavaCompiler
+          assert(javac != null, "No javac from getSystemJavaCompiler. If the java on your path isn't a JDK version, but $JAVA_HOME is, launch sbt with --java-home \"$JAVA_HOME\"")
+          val fileMan = javac.getStandardFileManager(null, null, null)
+          val javaFileObjects = fileMan.getJavaFileObjects(javaSources.map(s => tempFileFor(s).toAbsolutePath.toString): _*)
+          val task = javac.getTask(new OutputStreamWriter(System.out), fileMan, null, options.asJava, Nil.asJava, javaFileObjects)
+          val result = task.call()
+          Predef.assert(result)
+      }
+    }
+
+    for (group <- groups.init) {
+      compile(referenceOutput, group)
+    }
+    compile(referenceOutput, groups.last)
+
+    class CopyVisitor(src: Path, dest: Path) extends SimpleFileVisitor[Path] {
+      override def preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        Files.createDirectories(dest.resolve(src.relativize(dir)))
+        super.preVisitDirectory(dir, attrs)
+      }
+      override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        Files.copy(file, dest.resolve(src.relativize(file)))
+        super.visitFile(file, attrs)
+      }
+    }
+    for (permutation <- permutationsWithSubsets(groups.last)) {
+      val recompileOutput = Files.createTempDirectory("recompileOutput")
+      copyRecursive(referenceOutput, recompileOutput)
+      compile(recompileOutput, permutation)
+      assertDirectorySame(referenceOutput, recompileOutput, permutation.toString)
+      deleteRecursive(recompileOutput)
+    }
+    deleteRecursive(referenceOutput)
+
+  }
+  def permutationsWithSubsets[A](as: List[A]): List[List[A]] =
+    as.permutations.toList.flatMap(_.inits.filter(_.nonEmpty)).distinct
+
+}


### PR DESCRIPTION
```
sbt:root> junit/test:runMain scala.tools.nsc.DeterminismTester /Users/jz/code/scala/src/library

--- /var/folders/22/g1sv634d11j1d_lqlnhz9p2r0000gn/T/reference1538611564431125389/scala/Symbol.class
+++ /var/folders/22/g1sv634d11j1d_lqlnhz9p2r0000gn/T/recompileOutput2404148374994820649/scala/Symbol.class
@@ -1,17 +1,17 @@
 // class version 52.0 (52)
 // access flags 0x31
 public final class scala/Symbol implements scala/Serializable {

   // compiled from: Symbol.scala

-  @Lscala/reflect/ScalaSignature;(bytes="\u0006\u0001!4Aa\u0004\u0009\u0003'!A1\u0004\u0001BC\u0002\u0013\u0005A\u0004\u0003\u0005)\u0001\u0009\u0005\u0009\u0015!\u0003\u001e\u0011\u0015I\u0003\u0001\"\u0003+\u0011\u0015i\u0003\u0001\"\u0011/\u0011\u0015y\u0003\u0001\"\u00031\u0011\u0015\u0009\u0005\u0001\"\u0011C\u0011\u00151\u0005\u0001\"\u0011H\u000f\u0015i\u0005\u0003#\u0001O\r\u0015y\u0001\u0003#\u0001P\u0011\u0015I\u0013\u0002\"\u0001T\u0011\u0015!\u0016\u0002\"\u0011V\u0011\u00159\u0016\u0002\"\u0005Y\u0011\u0015Q\u0016\u0002\"\u0005\\\u0011\u001dy\u0013\"!A\u0005\n\u0005\u0014aaU=nE>d'\"A\u0009\u0002\u000bM\u001c\u0017\r\\1\u0004\u0001M\u0019\u0001\u0001\u0006\r\u0011\u0005U1R\"\u0001\u0009\n\u0005]\u0001\"AB!osJ+g\r\u0005\u0002\u00163%\u0011!\u0004\u0005\u0002\r'\u0016\u0014\u0018.\u00197ju\u0006\u0014G.Z\u0001\u0005]\u0006lW-F\u0001\u001e!\u0009qRE\u0004\u0002 GA\u0011\u0001\u0005E\u0007\u0002C)\u0011!EE\u0001\u0007yI|w\u000e\u001e \n\u0005\u0011\u0002\u0012A\u0002)sK\u0012,g-\u0003\u0002'O\u000911\u000b\u001e:j]\u001eT!\u0001\n\u0009\u0002\u000b9\u000cW.\u001a\u0011\u0002\rqJg.\u001b;?)\u0009YC\u0006\u0005\u0002\u0016\u0001!)1d\u0001a\u0001;\u0005AAo\\*ue&tw\rF\u0001\u001e\u0003-\u0011X-\u00193SKN|GN^3\u0015\u0003E\u0002\"!\u0006\u001a\n\u0005M\u0002\"aA!os\"\u001aQ!\u000e!\u0011\u0007U1\u0004(\u0003\u00028!\u00091A\u000f\u001b:poN\u0004\"!\u000f \u000e\u0003iR!a\u000f\u001f\u0002\u0005%|'\"A\u001f\u0002\u0009)\u000cg/Y\u0005\u0003i\u0012Qc\u00142kK\u000e$8\u000b\u001e:fC6,\u0005pY3qi&|gnI\u00019\u0003!A\u0017m\u001d5D_\u0012,G#A\"\u0011\u0005U!\u0015BA#\u0011\u0005\rIe\u000e^\u0001\u0007KF,\u0018\r\\:\u0015\u0005![\u0005CA\u000bJ\u0013\u0009Q\u0005CA\u0004C_>dW-\u00198\u0009\u000b1;\u0001\u0019A\u0019\u0002\u000b=$\u0008.\u001a:\u0002\rMKXNY8m!\u0009)\u0012bE\u0002\n!b\u0001B!F)\u001eW%\u0011!\u000b\u0005\u0002\u0010+:L\u0017/^3oKN\u001c8)Y2iKR\u0009a*A\u0003baBd\u0017\u0010\u0006\u0002,-\")1d\u0003a\u0001;\u0005aa/\u00197vK\u001a\u0013x.\\&fsR\u00111&\u0017\u0005\u000671\u0001\r!H\u0001\rW\u0016LhI]8n-\u0006dW/\u001a\u000b\u00039~\u00032!F/\u001e\u0013\u0009q\u0006C\u0001\u0004PaRLwN\u001c\u0005\u0006A6\u0001\raK\u0001\u0004gflG#\u00012\u0011\u0005\r4W\"\u00013\u000b\u0005\u0015d\u0014\u0001\u00027b]\u001eL!a\u001a3\u0003\r=\u0013'.Z2u\u0001")
+  @Lscala/reflect/ScalaSignature;(bytes="\u0006\u0001)4Aa\u0004\u0009\u0003'!A1\u0004\u0001BC\u0002\u0013\u0005A\u0004\u0003\u0005)\u0001\u0009\u0005\u0009\u0015!\u0003\u001e\u0011\u0015I\u0003\u0001\"\u0003+\u0011\u0015i\u0003\u0001\"\u0011/\u0011\u0015y\u0003\u0001\"\u00031\u0011\u0015\u0009\u0005\u0001\"\u0011C\u0011\u00151\u0005\u0001\"\u0011H\u000f\u0015i\u0005\u0003#\u0001O\r\u0015y\u0001\u0003#\u0001P\u0011\u0015I\u0013\u0002\"\u0001V\u0011\u00151\u0016\u0002\"\u0011X\u0011\u0015I\u0016\u0002\"\u0005[\u0011\u0015a\u0016\u0002\"\u0005^\u0011\u001dy\u0013\"!A\u0005\n\r\u0014aaU=nE>d'\"A\u0009\u0002\u000bM\u001c\u0017\r\\1\u0004\u0001M\u0019\u0001\u0001\u0006\r\u0011\u0005U1R\"\u0001\u0009\n\u0005]\u0001\"AB!osJ+g\r\u0005\u0002\u00163%\u0011!\u0004\u0005\u0002\r'\u0016\u0014\u0018.\u00197ju\u0006\u0014G.Z\u0001\u0005]\u0006lW-F\u0001\u001e!\u0009qRE\u0004\u0002 GA\u0011\u0001\u0005E\u0007\u0002C)\u0011!EE\u0001\u0007yI|w\u000e\u001e \n\u0005\u0011\u0002\u0012A\u0002)sK\u0012,g-\u0003\u0002'O\u000911\u000b\u001e:j]\u001eT!\u0001\n\u0009\u0002\u000b9\u000cW.\u001a\u0011\u0002\rqJg.\u001b;?)\u0009YC\u0006\u0005\u0002\u0016\u0001!)1d\u0001a\u0001;\u0005AAo\\*ue&tw\rF\u0001\u001e\u0003-\u0011X-\u00193SKN|GN^3\u0015\u0003E\u0002\"!\u0006\u001a\n\u0005M\u0002\"aA!os\"\u001aQ!\u000e!\u0011\u0007U1\u0004(\u0003\u00028!\u00091A\u000f\u001b:poN\u0004\"!\u000f \u000e\u0003iR!a\u000f\u001f\u0002\u0005%|'\"A\u001f\u0002\u0009)\u000cg/Y\u0005\u0003i\u0012Qc\u00142kK\u000e$8\u000b\u001e:fC6,\u0005pY3qi&|gnI\u00019\u0003!A\u0017m\u001d5D_\u0012,G#A\"\u0011\u0005U!\u0015BA#\u0011\u0005\rIe\u000e^\u0001\u0007KF,\u0018\r\\:\u0015\u0005![\u0005CA\u000bJ\u0013\u0009Q\u0005CA\u0004C_>dW-\u00198\u0009\u000b1;\u0001\u0019A\u0019\u0002\u000b=$\u0008.\u001a:\u0002\rMKXNY8m!\u0009)\u0012bE\u0002\n!b\u0001B!F)TW%\u0011!\u000b\u0005\u0002\u0010+:L\u0017/^3oKN\u001c8)Y2iKB\u0011a\u0004V\u0005\u0003M\u001d\"\u0012AT\u0001\u0006CB\u0004H.\u001f\u000b\u0003WaCQaG\u0006A\u0002u\u0009AB^1mk\u00164%o\\7LKf$\"aK.\u0009\u000bma\u0001\u0019A\u000f\u0002\u0019-,\u0017P\u0012:p[Z\u000bG.^3\u0015\u0005y\u000b\u0007cA\u000b`;%\u0011\u0001\r\u0005\u0002\u0007\u001fB$\u0018n\u001c8\u0009\u000b\u0009l\u0001\u0019A\u0016\u0002\u0007MLX\u000eF\u0001e!\u0009)\u0007.D\u0001g\u0015\u00099G(\u0001\u0003mC:<\u0017BA5g\u0005\u0019y%M[3di\u0002")
```