### PR TITLE
Fix range position for vars with default initializer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -568,7 +568,11 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.api.Internals#InternalApi.markForAsyncTransform"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.HashMap.entriesIterator0"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.ZipArchive.RootEntry"),
+
     ProblemFilters.exclude[MissingClassProblem]("scala.reflect.ClassTag$cache$"),
+
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.GenSet.setEquals"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.GenMap.mapEquals"),
   )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -568,6 +568,7 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.api.Internals#InternalApi.markForAsyncTransform"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.HashMap.entriesIterator0"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.ZipArchive.RootEntry"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.reflect.ClassTag$cache$"),
   )
 }
 

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -87,7 +87,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
   private[this] var currentReporter: FilteringReporter = null
   locally { reporter = reporter0 }
 
-  def reporter: Reporter = currentReporter
+  def reporter: FilteringReporter = currentReporter
   def reporter_=(newReporter: Reporter): Unit =
     currentReporter = newReporter match {
       case f: FilteringReporter => f

--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -144,4 +144,5 @@ abstract class TreeBuilder {
   }
 
   def makePatDef(mods: Modifiers, pat: Tree, rhs: Tree) = gen.mkPatDef(mods, pat, rhs)
+  def makePatDef(mods: Modifiers, pat: Tree, rhs: Tree, rhsPos: Position) = gen.mkPatDef(mods, pat, rhs, rhsPos)
 }

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1883,11 +1883,24 @@ trait Namers extends MethodSynthesis {
       annotations filterNot (_ eq null) map { ann =>
         val ctx = typer.context
         // need to be lazy, #1782. enteringTyper to allow inferView in annotation args, scala/bug#5892.
-        AnnotationInfo lazily {
-          enteringTyper {
-            val annotSig = newTyper(ctx.makeNonSilent(ann)).typedAnnotation(ann, Some(annotee))
-            if (pred(annotSig)) annotSig else UnmappableAnnotation // UnmappableAnnotation will be dropped in typedValDef and typedDefDef
-          }
+        def computeInfo: AnnotationInfo = enteringTyper {
+          val annotSig = newTyper(ctx.makeNonSilent(ann)).typedAnnotation(ann, Some(annotee))
+          if (pred(annotSig)) annotSig else UnmappableAnnotation // UnmappableAnnotation will be dropped in typedValDef and typedDefDef
+        }
+        ann match {
+          case treeInfo.Applied(Select(New(tpt), _), _, _) =>
+            // We can defer typechecking the arguments of annotations. This is important to avoid cycles in
+            // checking `hasAnnotation(UncheckedStable)` during typechecking.
+            def computeSymbol = enteringTyper {
+              val tptCopy = tpt.duplicate
+              val silentTyper  = newTyper(ctx.makeSilent(newtree = tptCopy))
+              // Discard errors here, we'll report them in `computeInfo`.
+              val tpt1 = silentTyper.typedTypeConstructor(tptCopy)
+              tpt1.tpe.finalResultType.typeSymbol
+            }
+            AnnotationInfo.lazily(computeSymbol, computeInfo)
+          case _ =>
+            AnnotationInfo.lazily(computeInfo)
         }
       }
 

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -97,9 +97,9 @@ import scala.io.StdIn
  * @groupprio implicit-classes-any 70
  * @groupdesc implicit-classes-any These implicit classes add useful extension methods to every type.
  *
- * @groupname implicit-classes-char CharSequence Conversions
- * @groupprio implicit-classes-char 80
- * @groupdesc implicit-classes-char These implicit classes add CharSequence methods to Array[Char] and IndexedSeq[Char] instances.
+ * @groupname char-sequence-wrappers CharSequence Wrappers
+ * @groupprio char-sequence-wrappers 80
+ * @groupdesc char-sequence-wrappers Wrappers that implements CharSequence and were implicit classes.
  *
  * @groupname conversions-java-to-anyval Java to Scala
  * @groupprio conversions-java-to-anyval 90
@@ -349,21 +349,27 @@ object Predef extends LowPriorityImplicits with DeprecatedPredef {
   // and `@deprecatedName(Symbol("<none>"), "2.12.0")` crashes scalac with
   //   scala.reflect.internal.Symbols$CyclicReference: illegal cyclic reference involving object Symbol
   // in run/repl-no-imports-no-predef-power.scala.
-  /** @group implicit-classes-char */
-  implicit final class SeqCharSequence(@deprecated("will be made private", "2.12.0") @deprecatedName(null, "2.12.0") val __sequenceOfChars: scala.collection.IndexedSeq[Char]) extends CharSequence {
+  /** @group char-sequence-wrappers */
+  final class SeqCharSequence(@deprecated("will be made private", "2.12.0") @deprecatedName(null, "2.12.0") val __sequenceOfChars: scala.collection.IndexedSeq[Char]) extends CharSequence {
     def length: Int                                     = __sequenceOfChars.length
     def charAt(index: Int): Char                        = __sequenceOfChars(index)
     def subSequence(start: Int, end: Int): CharSequence = new SeqCharSequence(__sequenceOfChars.slice(start, end))
     override def toString                               = __sequenceOfChars mkString ""
   }
 
-  /** @group implicit-classes-char */
-  implicit final class ArrayCharSequence(@deprecated("will be made private", "2.12.0") @deprecatedName(null, "2.12.0") val __arrayOfChars: Array[Char]) extends CharSequence {
+  /** @group char-sequence-wrappers */
+  def SeqCharSequence(sequenceOfChars: scala.collection.IndexedSeq[Char]): SeqCharSequence = new SeqCharSequence(sequenceOfChars)
+
+  /** @group char-sequence-wrappers */
+  final class ArrayCharSequence(@deprecated("will be made private", "2.12.0") @deprecatedName(null, "2.12.0") val __arrayOfChars: Array[Char]) extends CharSequence {
     def length: Int                                     = __arrayOfChars.length
     def charAt(index: Int): Char                        = __arrayOfChars(index)
     def subSequence(start: Int, end: Int): CharSequence = new runtime.ArrayCharSequence(__arrayOfChars, start, end)
     override def toString                               = __arrayOfChars mkString ""
   }
+
+  /** @group char-sequence-wrappers */
+  def ArrayCharSequence(arrayOfChars: Array[Char]): ArrayCharSequence = new ArrayCharSequence(arrayOfChars)
 
   implicit val StringCanBuildFrom: CanBuildFrom[String, Char, String] = new CanBuildFrom[String, Char, String] {
     def apply(from: String) = apply()

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -361,6 +361,7 @@ object Predef extends LowPriorityImplicits with DeprecatedPredef {
   def SeqCharSequence(sequenceOfChars: scala.collection.IndexedSeq[Char]): SeqCharSequence = new SeqCharSequence(sequenceOfChars)
 
   /** @group char-sequence-wrappers */
+  @deprecated("use `java.nio.CharBuffer.wrap` instead", "2.12.13")
   final class ArrayCharSequence(@deprecated("will be made private", "2.12.0") @deprecatedName(null, "2.12.0") val __arrayOfChars: Array[Char]) extends CharSequence {
     def length: Int                                     = __arrayOfChars.length
     def charAt(index: Int): Char                        = __arrayOfChars(index)
@@ -553,7 +554,7 @@ private[scala] trait DeprecatedPredef {
   @deprecated("use `StringFormat`", "2.11.0") def any2stringfmt(x: Any): StringFormat[Any]                                  = new StringFormat(x)
   @deprecated("use `Throwable` directly", "2.11.0") def exceptionWrapper(exc: Throwable)                                    = new RichException(exc)
   @deprecated("use `SeqCharSequence`", "2.11.0") def seqToCharSequence(xs: scala.collection.IndexedSeq[Char]): CharSequence = new SeqCharSequence(xs)
-  @deprecated("use `ArrayCharSequence`", "2.11.0") def arrayToCharSequence(xs: Array[Char]): CharSequence                   = new ArrayCharSequence(xs)
+  @deprecated("use `java.nio.CharBuffer.wrap`", "2.11.0") def arrayToCharSequence(xs: Array[Char]): CharSequence = new ArrayCharSequence(xs)
 
   @deprecated("use the method in `scala.io.StdIn`", "2.11.0") def readLine(): String                 = StdIn.readLine()
   @deprecated("use the method in `scala.io.StdIn`", "2.11.0") def readLine(text: String, args: Any*) = StdIn.readLine(text, args: _*)

--- a/src/library/scala/collection/GenMap.scala
+++ b/src/library/scala/collection/GenMap.scala
@@ -14,6 +14,7 @@ package scala
 package collection
 
 import generic._
+import scala.runtime.AbstractFunction1
 
 /** A trait for all traversable collections which may possibly
  *  have their operations implemented in parallel.
@@ -39,4 +40,24 @@ object GenMap extends GenMapFactory[GenMap] {
     ReusableCBF.asInstanceOf[CanBuildFrom[Coll, (K, V), GenMap[K, V]]]
   private[this] val ReusableCBF = new MapCanBuildFrom[Nothing, Nothing]
 
+  private[collection] def mapEquals[K1, V, K2](thisMap: GenMapLike[K1, V, _], thatMap: GenMap[K2, _]): Boolean = {
+    (thisMap eq thatMap) ||
+      (thatMap canEqual thisMap) &&
+        (thisMap.size == thatMap.size) && {
+        try {
+          val checker = new AbstractFunction1[(K1, V),Boolean] with Function0[V]{
+            override def apply(kv: (K1,V)): Boolean = {
+              // Note: uncurry optimizes this to `get.getOrElse(..., this: Function0)`;  there is no extra lambda allocated.
+              val v2 = thatMap.getOrElse(kv._1.asInstanceOf[K2], this.apply())
+              // A mis-behaving user-defined equals method might not expect the sentinel value, and we should try to limit
+              // the chance of it escaping. Its also probably quicker to avoid the virtual call to equals.
+              (v2.asInstanceOf[AnyRef] ne this) && v2 == kv._2
+            }
+            override def apply(): V = this.asInstanceOf[V]
+          }
+          thisMap forall checker
+        } catch {
+          case ex: ClassCastException => false
+        }}
+  }
 }

--- a/src/library/scala/collection/GenSet.scala
+++ b/src/library/scala/collection/GenSet.scala
@@ -37,5 +37,12 @@ extends GenSetLike[A, GenSet[A]]
 object GenSet extends GenTraversableFactory[GenSet] {
   implicit def canBuildFrom[A] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
   def newBuilder[A] = Set.newBuilder
+  private[collection] def setEquals[A1, A2](thisSet: GenSetLike[A1, _], thatSet: GenSet[A2]): Boolean = {
+    (thisSet eq thatSet) ||
+      (thatSet canEqual thisSet) &&
+        (thisSet.size == thatSet.size) &&
+        (try thisSet subsetOf thatSet.asInstanceOf[GenSet[A1]]
+        catch { case ex: ClassCastException => false })
+  }
 }
 

--- a/src/library/scala/collection/GenSetLike.scala
+++ b/src/library/scala/collection/GenSetLike.scala
@@ -117,12 +117,9 @@ extends GenIterableLike[A, Repr]
    *              as this set.
    */
   override def equals(that: Any): Boolean = that match {
+    // copy/pasted to immutable.SortedSet.equals for binary compat reasons!
     case that: GenSet[_] =>
-      (this eq that) ||
-      (that canEqual this) &&
-      (this.size == that.size) &&
-      (try this subsetOf that.asInstanceOf[GenSet[A]]
-       catch { case ex: ClassCastException => false })
+      GenSet.setEquals(this, that)
     case _ =>
       false
   }

--- a/src/library/scala/collection/immutable/SortedMap.scala
+++ b/src/library/scala/collection/immutable/SortedMap.scala
@@ -114,7 +114,11 @@ self =>
           allEqual = i1.next() == i2.next()
         allEqual
       }
-    case _ => super.equals(that)
+    // copy/pasted from super.equals for binary compat reasons!
+    case that: GenMap[b, _] =>
+      GenMap.mapEquals(this, that)
+    case _ =>
+      false && super.equals(that) // generate unused super accessor for binary compatibility (scala/scala#9311)
   }
 }
 

--- a/src/library/scala/collection/immutable/SortedSet.scala
+++ b/src/library/scala/collection/immutable/SortedSet.scala
@@ -41,8 +41,11 @@ trait SortedSet[A] extends Set[A] with scala.collection.SortedSet[A] with Sorted
           allEqual = i1.next() == i2.next
         allEqual
       }
+    // copy/pasted from super.equals for binary compat reasons!
+    case that: GenSet[_] =>
+      GenSet.setEquals(this, that)
     case _ =>
-      super.equals(that)
+      false && super.equals(that) // generate unused super accessor for binary compatibility (scala/scala#9311)
   }
 }
 /** $factoryInfo

--- a/src/library/scala/collection/mutable/StringBuilder.scala
+++ b/src/library/scala/collection/mutable/StringBuilder.scala
@@ -447,6 +447,15 @@ final class StringBuilder(private val underlying: JavaStringBuilder)
    *  @return  the string assembled by this StringBuilder
    */
   def result(): String = toString
+
+
+  /** Tests whether this builder is empty.
+   *
+   *  This method is required for JDK15+ compatibility
+   *
+   *  @return  `true` if this builder contains nothing, `false` otherwise.
+   */
+  override def isEmpty: Boolean = underlying.length() == 0
 }
 
 object StringBuilder {

--- a/src/library/scala/reflect/ClassTag.scala
+++ b/src/library/scala/reflect/ClassTag.scala
@@ -53,7 +53,7 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
 
   @transient private[scala] lazy val emptyArray       : Array[T]                = {
     val componentType =
-      if (runtimeClass eq classOf[Void]) classOf[BoxedUnit] else runtimeClass
+      if (runtimeClass eq java.lang.Void.TYPE) classOf[BoxedUnit] else runtimeClass
     java.lang.reflect.Array.newInstance(componentType, 0).asInstanceOf[Array[T]]
   }
   @transient private[scala] lazy val emptyWrappedArray: mutable.WrappedArray[T] =

--- a/src/library/scala/reflect/ClassTag.scala
+++ b/src/library/scala/reflect/ClassTag.scala
@@ -14,6 +14,7 @@ package scala
 package reflect
 
 import java.lang.{ Class => jClass }
+import java.lang.ref.{WeakReference => jWeakReference}
 
 import scala.collection.mutable
 import scala.runtime.BoxedUnit
@@ -136,16 +137,19 @@ object ClassTag {
   val Nothing : ClassTag[scala.Nothing]    = Manifest.Nothing
   val Null    : ClassTag[scala.Null]       = Manifest.Null
 
-  private[this] val cache = new ClassValue[ClassTag[_]] {
-    override def computeValue(runtimeClass: jClass[_]): ClassTag[_] = {
+  private val cacheDisabledProp = scala.sys.Prop[String]("scala.reflect.classtag.cache.disable")
+  private[this] object cache extends ClassValue[jWeakReference[ClassTag[_]]] {
+    override def computeValue(runtimeClass: jClass[_]): jWeakReference[ClassTag[_]] =
+      new jWeakReference(computeTag(runtimeClass))
+
+    def computeTag(runtimeClass: jClass[_]): ClassTag[_] =
       runtimeClass match {
         case x if x.isPrimitive => primitiveClassTag(runtimeClass)
         case ObjectTYPE         => ClassTag.Object
         case NothingTYPE        => ClassTag.Nothing
         case NullTYPE           => ClassTag.Null
         case _                  => new GenericClassTag[AnyRef](runtimeClass)
-      }
-    }
+     }
 
     private def primitiveClassTag[T](runtimeClass: Class[_]): ClassTag[_] = runtimeClass match {
       case java.lang.Byte.TYPE      => ClassTag.Byte
@@ -168,7 +172,19 @@ object ClassTag {
     }
   }
 
-  def apply[T](runtimeClass1: jClass[_]): ClassTag[T] = cache.get(runtimeClass1).asInstanceOf[ClassTag[T]]
+  def apply[T](runtimeClass1: jClass[_]): ClassTag[T] = {
+    if (cacheDisabledProp.isSet)
+      cache.computeTag(runtimeClass1).asInstanceOf[ClassTag[T]]
+    else {
+      val ref = cache.get(runtimeClass1).asInstanceOf[jWeakReference[ClassTag[T]]]
+      var tag = ref.get
+      if (tag == null) {
+        cache.remove(runtimeClass1)
+        tag = cache.computeTag(runtimeClass1).asInstanceOf[ClassTag[T]]
+      }
+      tag
+    }
+  }
 
   def unapply[T](ctag: ClassTag[T]): Option[Class[_]] = Some(ctag.runtimeClass)
 }

--- a/src/library/scala/runtime/SeqCharSequence.scala
+++ b/src/library/scala/runtime/SeqCharSequence.scala
@@ -21,8 +21,7 @@ final class SeqCharSequence(val xs: scala.collection.IndexedSeq[Char]) extends C
   override def toString = xs.mkString("")
 }
 
-// Still need this one since the implicit class ArrayCharSequence only converts
-// a single argument.
+@deprecated("use `java.nio.CharBuffer.wrap` instead", "2.12.13")
 final class ArrayCharSequence(val xs: Array[Char], start: Int, end: Int) extends CharSequence {
   // yikes
   // java.lang.VerifyError: (class: scala/runtime/ArrayCharSequence, method: <init> signature: ([C)V)

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -188,12 +188,17 @@ trait Names extends api.Names {
 
 // Classes ----------------------------------------------------------------------
 
+  // Dummy trait to make Name#isEmpty with override keyword at JDK before 15
+  sealed trait NameHasIsEmpty {
+    def isEmpty: Boolean
+  }
+
   /** The name class.
    *  TODO - resolve schizophrenia regarding whether to treat Names as Strings
    *  or Strings as Names.  Give names the key functions the absence of which
    *  make people want Strings all the time.
    */
-  sealed abstract class Name(protected val index: Int, protected val len: Int, protected val cachedString: String) extends NameApi with CharSequence {
+  sealed abstract class Name(protected val index: Int, protected val len: Int, protected val cachedString: String) extends NameApi with NameHasIsEmpty with CharSequence {
     type ThisNameType >: Null <: Name
     protected[this] def thisName: ThisNameType
 
@@ -209,8 +214,9 @@ trait Names extends api.Names {
 
     /** The length of this name. */
     final def length: Int = len
-    final def isEmpty = length == 0
     final def nonEmpty = !isEmpty
+    // This method is implements NameHasIsEmpty, and overrides CharSequence's isEmpty on JDK 15+
+    override final def isEmpty = length == 0
 
     def nameKind: String
     def isTermName: Boolean

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -77,7 +77,7 @@ trait StdNames {
       val suffix = s takeRight edge
 
       val cs = s.toArray
-      val bytes = Codec toUTF8 cs
+      val bytes = Codec.toUTF8(new scala.runtime.ArrayCharSequence(cs, 0, cs.length))
       md5 update bytes
       val md5chars = (md5.digest() map (b => (b & 0xFF).toHexString)).mkString
 

--- a/test/files/jvm/interpreter.check
+++ b/test/files/jvm/interpreter.check
@@ -93,6 +93,7 @@ scala> case class Bar(n: Int)
 defined class Bar
 
 scala> implicit def foo2bar(foo: Foo) = Bar(foo.n)
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 foo2bar: (foo: Foo)Bar
 
 scala> val bar: Bar = Foo(3)
@@ -266,6 +267,7 @@ scala> xs map (x => x)
 res6: Array[_] = Array(1, 2)
 
 scala> xs map (x => (x, x))
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 res7: Array[(_$1, _$1)] forSome { type _$1 } = Array((1,1), (2,2))
 
 scala> 
@@ -351,6 +353,10 @@ defined class Term
 scala> def f(e: Exp) = e match {  // non-exhaustive warning here
   case _:Fact => 3
 }
+<console>:18: warning: match may not be exhaustive.
+It would fail on the following inputs: Exp(), Term()
+def f(e: Exp) = e match {  // non-exhaustive warning here
+                ^
 f: (e: Exp)Int
 
 scala> :quit

--- a/test/files/pos/annotation-cycle.scala
+++ b/test/files/pos/annotation-cycle.scala
@@ -1,0 +1,7 @@
+import scala.annotation.StaticAnnotation
+
+class anno(attr: Boolean) extends StaticAnnotation
+
+object Test {
+  @anno(attr = true) def attr: Int = 1
+}

--- a/test/files/pos/t11870.scala
+++ b/test/files/pos/t11870.scala
@@ -1,0 +1,60 @@
+class Annot(arg: Any) extends scala.annotation.StaticAnnotation
+
+abstract class Demo1 {
+  @Annot(x)
+  def x: String = "foo"
+}
+
+abstract class Demo2 {
+  @Annot(y)
+  def x: String = "foo"
+
+  @Annot(x)
+  def y: String = "bar"
+}
+
+class Annot1(arg: Any) extends scala.annotation.StaticAnnotation
+class Annot2(arg: Any) extends scala.annotation.StaticAnnotation
+
+abstract class Demo3 {
+  @Annot1(y)
+  def x: String = "foo"
+
+  @Annot2(x)
+  def y: String = "bar"
+}
+
+// test annotations without argument
+import scala.annotation.unchecked
+
+class C {
+  class D
+}
+
+class Test {
+  locally {
+    val c = new C
+    import c._
+    new D
+  }
+
+  locally {
+    import unchecked.uncheckedStable
+    @uncheckedStable def c = new C
+    import c._
+    new D
+  }
+
+  locally {
+    @unchecked.uncheckedStable def c = new C
+    import c._
+    new D
+  }
+
+  locally {
+    import unchecked.{uncheckedStable => uc}
+    @uc def c = new C
+    import c._
+    new D
+  }
+}

--- a/test/files/pos/unchecked-stable-cyclic-error.scala
+++ b/test/files/pos/unchecked-stable-cyclic-error.scala
@@ -1,0 +1,8 @@
+import scala.annotation.StaticAnnotation
+
+class anno(a: Any) extends StaticAnnotation
+
+object Test {
+  def foo = attr
+  @anno(foo) def attr: Int = foo
+}

--- a/test/files/run/array-charSeq.scala
+++ b/test/files/run/array-charSeq.scala
@@ -1,6 +1,6 @@
 object Test {
   val arr = Array[Char]('a' to 'i': _*)
-  var xs: CharSequence = arr
+  var xs: CharSequence = ArrayCharSequence(arr)
   val hash = xs.hashCode
 
   def check(chars: CharSequence) {

--- a/test/files/run/constrained-types.check
+++ b/test/files/run/constrained-types.check
@@ -69,9 +69,11 @@ scala> var four = "four"
 four: String = four
 
 scala> val four2 = m(four) // should have an existential bound
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 four2: String @Annot(x) forSome { val x: String } = four
 
 scala> val four3 = four2   // should have the same type as four2
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 four3: String @Annot(x) forSome { val x: String } = four
 
 scala> val stuff = m("stuff") // should not crash
@@ -94,6 +96,7 @@ scala> def m = {
   val y : String @Annot(x) = x
   y
 } // x should not escape the local scope with a narrow type
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 m: String @Annot(x) forSome { val x: String }
 
 scala> 
@@ -107,6 +110,7 @@ scala> def n(y: String) = {
   }
   m("stuff".stripMargin)
 } // x should be existentially bound
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 n: (y: String)String @Annot(x) forSome { val x: String }
 
 scala> 

--- a/test/files/run/reflection-magicsymbols-repl.check
+++ b/test/files/run/reflection-magicsymbols-repl.check
@@ -19,6 +19,7 @@ scala> def test(n: Int): Unit = {
   val x = sig.asInstanceOf[MethodType].params.head
   println(x.info)
 }
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 test: (n: Int)Unit
 
 scala> for (i <- 1 to 8) test(i)

--- a/test/files/run/repl-bare-expr.check
+++ b/test/files/run/repl-bare-expr.check
@@ -1,14 +1,32 @@
 
 scala> 2 ; 3
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+2 ;;
+^
 res0: Int = 3
 
 scala> { 2 ; 3 }
+<console>:12: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+{ 2 ; 3 }
+  ^
 res1: Int = 3
 
 scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
   1 +
   2 +
   3 } ; bippy+88+11
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+    ^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+                           ^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+                                                                                  ^
 defined object Cow
 defined class Moo
 bippy: Int

--- a/test/files/run/repl-class-based-outer-pointers.check
+++ b/test/files/run/repl-class-based-outer-pointers.check
@@ -8,6 +8,9 @@ defined class Value
 defined object Value
 
 scala> class C { final case class Num(value: Double) } // here it should still warn
+<console>:11: warning: The outer reference in this type test cannot be checked at run time.
+class C { final case class Num(value: Double) } // here it should still warn
+                           ^
 defined class C
 
 scala> :quit

--- a/test/files/run/repl-no-imports-no-predef-power.check
+++ b/test/files/run/repl-no-imports-no-predef-power.check
@@ -7,9 +7,11 @@ Try :help or completions for vals._ and power._
 scala> // guarding against "error: reference to global is ambiguous"
 
 scala> global.emptyValDef  // "it is imported twice in the same scope by ..."
+warning: one deprecation (since 2.11.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res0: $r.global.noSelfType.type = private val _ = _
 
 scala> val tp = ArrayClass[scala.util.Random]    // magic with tags
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 tp: $r.global.Type = Array[scala.util.Random]
 
 scala> tp.memberType(Array_apply)                // evidence

--- a/test/files/run/repl-no-imports-no-predef.check
+++ b/test/files/run/repl-no-imports-no-predef.check
@@ -76,9 +76,15 @@ y: Int = 13
 scala> 
 
 scala> 2 ; 3
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+2 ;;
+^
 res14: Int = 3
 
 scala> { 2 ; 3 }
+<console>:12: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+{ 2 ; 3 }
+  ^
 res15: Int = 3
 
 scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
@@ -86,6 +92,18 @@ bippy = {
   1 +
   2 +
   3 } ; bippy+88+11
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+    ^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+                           ^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+                                                                                  ^
 defined object Cow
 defined class Moo
 bippy: Int
@@ -125,6 +143,12 @@ scala>   (  (2 + 2 )  )
 res24: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ;   (  (2 + 2 )  ) ;;
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ;   (  (2 + 2 )  ) ;;
+            ^
 res25: Int = 5
 
 scala> (((2 + 2)), ((2 + 2)))
@@ -139,9 +163,18 @@ res28: String = 4423
 scala> 
 
 scala> 55 ; ((2 + 2)) ; (1, 2, 3)
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; ((2 + 2)) ;;
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; ((2 + 2)) ;;
+         ^
 res29: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: scala.Int) => x + 1 ; () => ((5))
+<console>:12: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; (x: scala.Int) => x + 1 ;;
+^
 res30: () => Int = <function>
 
 scala> 
@@ -150,6 +183,9 @@ scala> () => 5
 res31: () => Int = <function>
 
 scala> 55 ; () => 5
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ;;
+^
 res32: () => Int = <function>
 
 scala> () => { class X ; new X }

--- a/test/files/run/repl-parens.check
+++ b/test/files/run/repl-parens.check
@@ -18,6 +18,12 @@ scala>   (  (2 + 2 )  )
 res5: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ;   (  (2 + 2 )  ) ;;
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ;   (  (2 + 2 )  ) ;;
+            ^
 res6: Int = 5
 
 scala> (((2 + 2)), ((2 + 2)))
@@ -32,9 +38,18 @@ res9: String = 4423
 scala> 
 
 scala> 55 ; ((2 + 2)) ; (1, 2, 3)
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; ((2 + 2)) ;;
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; ((2 + 2)) ;;
+         ^
 res10: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: Int) => x + 1 ; () => ((5))
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; (x: Int) => x + 1 ;;
+^
 res11: () => Int = <function>
 
 scala> 
@@ -43,6 +58,9 @@ scala> () => 5
 res12: () => Int = <function>
 
 scala> 55 ; () => 5
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ;;
+^
 res13: () => Int = <function>
 
 scala> () => { class X ; new X }

--- a/test/files/run/repl-power.check
+++ b/test/files/run/repl-power.check
@@ -7,9 +7,11 @@ Try :help or completions for vals._ and power._
 scala> // guarding against "error: reference to global is ambiguous"
 
 scala> global.emptyValDef  // "it is imported twice in the same scope by ..."
+warning: one deprecation (since 2.11.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res0: $r.global.noSelfType.type = private val _ = _
 
 scala> val tp = ArrayClass[scala.util.Random]    // magic with tags
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 tp: $r.global.Type = Array[scala.util.Random]
 
 scala> tp.memberType(Array_apply)                // evidence

--- a/test/files/run/t11402.check
+++ b/test/files/run/t11402.check
@@ -1,0 +1,14 @@
+
+scala> import scala.concurrent.duration._; val t = 1 second
+<console>:11: warning: postfix operator second should be enabled
+by making the implicit value scala.language.postfixOps visible.
+This can be achieved by adding the import clause 'import scala.language.postfixOps'
+or by setting the compiler option -language:postfixOps.
+See the Scaladoc for value scala.language.postfixOps for a discussion
+why the feature should be explicitly enabled.
+import scala.concurrent.duration._; val t = 1 second
+                                              ^
+import scala.concurrent.duration._
+t: scala.concurrent.duration.FiniteDuration = 1 second
+
+scala> :quit

--- a/test/files/run/t11402.scala
+++ b/test/files/run/t11402.scala
@@ -1,0 +1,12 @@
+import scala.tools.nsc.Settings
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def transformSettings(ss: Settings) = {
+    ss.feature.value = true
+    ss
+  }
+
+  // From zinc's InteractiveConsoleInterfaceSpecification "should evaluate postfix op with a warning"
+  override def code = "import scala.concurrent.duration._; val t = 1 second"
+}

--- a/test/files/run/t4172.check
+++ b/test/files/run/t4172.check
@@ -1,5 +1,6 @@
 
 scala> val c = { class C { override def toString = "C" }; ((new C, new C { def f = 2 })) }
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 c: (C, C{def f: Int}) forSome { type C <: AnyRef } = (C,C)
 
 scala> :quit

--- a/test/files/run/t4542.check
+++ b/test/files/run/t4542.check
@@ -5,6 +5,9 @@ scala> @deprecated("foooo", "ReplTest version 1.0-FINAL") class Foo() {
 defined class Foo
 
 scala> val f = new Foo
+<console>:12: warning: class Foo is deprecated (since ReplTest version 1.0-FINAL): foooo
+val f = new Foo
+            ^
 f: Foo = Bippy
 
 scala> :quit

--- a/test/files/run/t4594-repl-settings.check
+++ b/test/files/run/t4594-repl-settings.check
@@ -3,11 +3,15 @@ scala> @deprecated(message="Please don't do that.", since="Time began.") def dep
 depp: String
 
 scala> def a = depp
+warning: one deprecation (since Time began.); for details, enable `:setting -deprecation' or `:replay -deprecation'
 a: String
 
 scala> :settings -deprecation
 
 scala> def b = depp
+<console>:12: warning: method depp is deprecated (since Time began.): Please don't do that.
+def b = depp
+        ^
 b: String
 
 scala> :quit

--- a/test/files/run/t4710.check
+++ b/test/files/run/t4710.check
@@ -1,5 +1,6 @@
 
 scala> def method : String = { implicit def f(s: Symbol) = "" ; 'symbol }
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 method: String
 
 scala> :quit

--- a/test/files/run/t6329_repl.check
+++ b/test/files/run/t6329_repl.check
@@ -3,24 +3,28 @@ scala> import scala.reflect.classTag
 import scala.reflect.classTag
 
 scala> classManifest[scala.List[_]]
+warning: one deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res0: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[<?>]
 
 scala> classTag[scala.List[_]]
 res1: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List
 
 scala> classManifest[scala.collection.immutable.List[_]]
+warning: one deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res2: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[<?>]
 
 scala> classTag[scala.collection.immutable.List[_]]
 res3: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List
 
 scala> classManifest[Predef.Set[_]]
+warning: one deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res4: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set[<?>]
 
 scala> classTag[Predef.Set[_]]
 res5: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set
 
 scala> classManifest[scala.collection.immutable.Set[_]]
+warning: one deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res6: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set[<?>]
 
 scala> classTag[scala.collection.immutable.Set[_]]

--- a/test/files/run/t6329_repl_bug.check
+++ b/test/files/run/t6329_repl_bug.check
@@ -6,6 +6,7 @@ scala> import scala.reflect.runtime._
 import scala.reflect.runtime._
 
 scala> classManifest[List[_]]
+warning: one deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res0: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[<?>]
 
 scala> scala.reflect.classTag[List[_]]

--- a/test/files/run/t7319.check
+++ b/test/files/run/t7319.check
@@ -3,12 +3,15 @@ scala> class M[A]
 defined class M
 
 scala> implicit def ma0[A](a: A): M[A] = null
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 ma0: [A](a: A)M[A]
 
 scala> implicit def ma1[A](a: A): M[A] = null
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 ma1: [A](a: A)M[A]
 
 scala> def convert[F[X <: F[X]]](builder: F[_ <: F[_]]) = 0
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 convert: [F[X <: F[X]]](builder: F[_ <: F[_]])Int
 
 scala> convert(Some[Int](0))

--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -15,15 +15,33 @@ scala> val z = x * y
 z: Int = 156
 
 scala> 2 ; 3
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+2 ;;
+^
 res0: Int = 3
 
 scala> { 2 ; 3 }
+<console>:12: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+{ 2 ; 3 }
+  ^
 res1: Int = 3
 
 scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
   1 +
   2 +
   3 } ; bippy+88+11
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+    ^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+                           ^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+                                                                                  ^
 defined object Cow
 defined class Moo
 bippy: Int
@@ -63,6 +81,12 @@ scala>   (  (2 + 2 )  )
 res10: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ;   (  (2 + 2 )  ) ;;
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ;   (  (2 + 2 )  ) ;;
+            ^
 res11: Int = 5
 
 scala> (((2 + 2)), ((2 + 2)))
@@ -77,9 +101,18 @@ res14: String = 4423
 scala> 
 
 scala> 55 ; ((2 + 2)) ; (1, 2, 3)
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; ((2 + 2)) ;;
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; ((2 + 2)) ;;
+         ^
 res15: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: Int) => x + 1 ; () => ((5))
+<console>:12: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; (x: Int) => x + 1 ;;
+^
 res16: () => Int = <function>
 
 scala> 
@@ -88,6 +121,9 @@ scala> () => 5
 res17: () => Int = <function>
 
 scala> 55 ; () => 5
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ;;
+^
 res18: () => Int = <function>
 
 scala> () => { class X ; new X }

--- a/test/files/run/xMigration.check
+++ b/test/files/run/xMigration.check
@@ -10,6 +10,10 @@ res1: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 scala> :setting -Xmigration:any
 
 scala> Map(1 -> "eis").values    // warn
+<console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
+`values` returns `Iterable[V]` rather than `Iterator[V]`.
+Map(1 -> "eis").values    // warn
+                ^
 res2: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 
 scala> :setting -Xmigration:2.8
@@ -20,6 +24,10 @@ res3: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 scala> :setting -Xmigration:2.7
 
 scala> Map(1 -> "eis").values    // warn
+<console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
+`values` returns `Iterable[V]` rather than `Iterator[V]`.
+Map(1 -> "eis").values    // warn
+                ^
 res4: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 
 scala> :setting -Xmigration:2.11
@@ -30,6 +38,10 @@ res5: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 scala> :setting -Xmigration      // same as :any
 
 scala> Map(1 -> "eis").values    // warn
+<console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
+`values` returns `Iterable[V]` rather than `Iterator[V]`.
+Map(1 -> "eis").values    // warn
+                ^
 res6: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 
 scala> :quit

--- a/test/junit/scala/ArrayTest.scala
+++ b/test/junit/scala/ArrayTest.scala
@@ -1,17 +1,20 @@
 package scala
 
-import org.junit.Assert.{ assertArrayEquals, assertFalse, assertTrue }
+import org.junit.Assert.{ assertFalse, assertTrue }
 import org.junit.Test
-
-import scala.runtime.BoxedUnit
 
 class ArrayTest {
 
   @Test
   def testArrayIsEmpty(): Unit = {
     assertTrue(Array[Int]().isEmpty)
+    assertTrue(Array.empty[Int].isEmpty)
     assertTrue(Array[Char]().isEmpty) // scala/bug#12172
+    assertTrue(Array.empty[Char].isEmpty)
     assertTrue(Array[String]().isEmpty)
+    assertTrue(Array.empty[String].isEmpty)
+    assertTrue(Array[Unit]().isEmpty)
+    assertTrue(Array.empty[Unit].isEmpty)
 
     assertFalse(Array(1).isEmpty)
     assertFalse(Array[Char](1).isEmpty)

--- a/test/junit/scala/ArrayTest.scala
+++ b/test/junit/scala/ArrayTest.scala
@@ -1,0 +1,30 @@
+package scala
+
+import org.junit.Assert.{ assertArrayEquals, assertFalse, assertTrue }
+import org.junit.Test
+
+import scala.runtime.BoxedUnit
+
+class ArrayTest {
+
+  @Test
+  def testArrayIsEmpty(): Unit = {
+    assertTrue(Array[Int]().isEmpty)
+    assertTrue(Array[Char]().isEmpty) // scala/bug#12172
+    assertTrue(Array[String]().isEmpty)
+
+    assertFalse(Array(1).isEmpty)
+    assertFalse(Array[Char](1).isEmpty)
+    assertFalse(Array("").isEmpty)
+
+    def ge[T](a: Array[T]) = a.isEmpty
+
+    assertTrue(ge(Array[Int]()))
+    assertTrue(ge(Array[Char]()))
+    assertTrue(ge(Array[String]()))
+
+    assertFalse(ge(Array(1)))
+    assertFalse(ge(Array[Char]('x')))
+    assertFalse(ge(Array("")))
+  }
+}

--- a/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
@@ -312,4 +312,17 @@ class BytecodeTest extends BytecodeTesting {
     val a = A.fields.asScala.find(_.name == "a").get
     assertEquals(0, a.access & Opcodes.ACC_FINAL)
   }
+
+  @Test
+  def sortedSetMapEqualsSuperAccessor(): Unit = {
+    // ensure super accessors are there (scala/scala#9311)
+
+    val sn = "scala$collection$immutable$SortedSet$$super$equals"
+    val sm = classOf[scala.collection.immutable.TreeSet[_]].getDeclaredMethod(sn, classOf[Object])
+    assertEquals(sn, sm.getName)
+
+    val mn = "scala$collection$immutable$SortedMap$$super$equals"
+    val mm = classOf[scala.collection.immutable.TreeMap[_, _]].getDeclaredMethod(mn, classOf[Object])
+    assertEquals(mn, mm.getName)
+  }
 }

--- a/test/junit/scala/tools/nsc/parser/ParserTest.scala
+++ b/test/junit/scala/tools/nsc/parser/ParserTest.scala
@@ -43,6 +43,6 @@ class ParserTest extends BytecodeTesting{
     def codeOf(pos: Position) = new String(pos.source.content.slice(pos.start, pos.end))
     val List(x, y) = unit.body.collect { case vd : ValDef => vd }.takeRight(2)
     assertEquals("var y: Int = 42", codeOf(y.pos))
-    assertEquals("var x: Int", codeOf(x.pos)) // TODO fix parser to include `= _`
+    assertEquals("var x: Int = _", codeOf(x.pos)) // TODO fix parser to include `= _`
   }
 }

--- a/test/junit/scala/tools/nsc/parser/ParserTest.scala
+++ b/test/junit/scala/tools/nsc/parser/ParserTest.scala
@@ -3,6 +3,7 @@ package scala.tools.nsc.parser
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import org.junit.Assert._
 
 import scala.tools.testing.BytecodeTesting
 
@@ -28,5 +29,20 @@ class ParserTest extends BytecodeTesting{
     run.compileSources(newSourceFile(lfCode) :: Nil)
     assert(!reporter.hasErrors)
     run.compileSources(newSourceFile(crlfCode) :: Nil)
+  }
+
+  @Test
+  def rangePosOfDefaultInitializer_t12213(): Unit = {
+    val code =
+      """object Other { var x: Int = _; var y: Int = 42 }"""
+    import compiler._, global._
+    val run = new Run
+    run.compileSources(newSourceFile(code) :: Nil)
+    assert(!reporter.hasErrors)
+    val unit = run.units.toList.head
+    def codeOf(pos: Position) = new String(pos.source.content.slice(pos.start, pos.end))
+    val List(x, y) = unit.body.collect { case vd : ValDef => vd }.takeRight(2)
+    assertEquals("var y: Int = 42", codeOf(y.pos))
+    assertEquals("var x: Int", codeOf(x.pos)) // TODO fix parser to include `= _`
   }
 }


### PR DESCRIPTION
```
➜  scala git:(2.12.x) ✗ sbt "scala -Yrangepos"
[info] Loading settings for project global-plugins from idea.sbt,dirtymoney.sbt,metals.sbt,gpg.sbt ...
[info] Loading global plugins from /Users/jz/.sbt/1.0/plugins
[info] Loading settings for project scala-build-build from plugins.sbt ...
[info] Loading project definition from /Users/jz/code/scala/project/project
[info] Loading settings for project scala-build from plugins.sbt,build.sbt ...
[info] Loading project definition from /Users/jz/code/scala/project
[info] Loading settings for project root from build.sbt ...
[info] Resolving key references (18463 settings) ...
[info] *** Welcome to the sbt build definition for Scala! ***
[info] version=2.12.13-bin-SNAPSHOT scalaVersion=2.12.12
[info] Check README.md for more information.
[info] Compiling 1 Scala source to /Users/jz/code/scala/build/quick/classes/compiler ...
[info] running (fork) scala.tools.nsc.MainGenericRunner -usejavacp -Yrangepos
Welcome to Scala 2.12.13-20201022-125904-2ab9556 (OpenJDK 64-Bit Server VM, Java 1.8.0_262).
Type in expressions for evaluation. Or try :help.

scala> :power
Power mode enabled. :phase is at typer.
import scala.tools.nsc._, intp.global._, definitions._
Try :help or completions for vals._ and power._

scala> object Other { var x: Int = _; var y: Int = 42 }
defined object Other

scala> val trees = lastRequest.trees
trees: List[$r.intp.global.Tree] =
List(object Other extends scala.AnyRef {
  def <init>() = {
    super.<init>();
    ()
  };
  var x: Int = _;
  var y: Int = 42
})

scala> val List(x, y) = trees.flatMap(_.collect { case vd : ValDef => vd }.takeRight(2))
x: $r.intp.global.ValDef = var x: Int = _
y: $r.intp.global.ValDef = var y: Int = 42

scala> x.pos
res0: $r.intp.global.Position = RangePosition(<console>, 15, 19, 29)

scala> x.pos.source.content(x.pos.end)
res1: Char = ;
```

Fixes scala/bug#12213