### PR TITLE
Dignostic code for RedBlackTree

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -568,6 +568,7 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.api.Internals#InternalApi.markForAsyncTransform"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.HashMap.entriesIterator0"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.ZipArchive.RootEntry"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.reflect.ClassTag$cache$"),
   )
 }
 

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -87,7 +87,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
   private[this] var currentReporter: FilteringReporter = null
   locally { reporter = reporter0 }
 
-  def reporter: Reporter = currentReporter
+  def reporter: FilteringReporter = currentReporter
   def reporter_=(newReporter: Reporter): Unit =
     currentReporter = newReporter match {
       case f: FilteringReporter => f

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1883,11 +1883,24 @@ trait Namers extends MethodSynthesis {
       annotations filterNot (_ eq null) map { ann =>
         val ctx = typer.context
         // need to be lazy, #1782. enteringTyper to allow inferView in annotation args, scala/bug#5892.
-        AnnotationInfo lazily {
-          enteringTyper {
-            val annotSig = newTyper(ctx.makeNonSilent(ann)).typedAnnotation(ann, Some(annotee))
-            if (pred(annotSig)) annotSig else UnmappableAnnotation // UnmappableAnnotation will be dropped in typedValDef and typedDefDef
-          }
+        def computeInfo: AnnotationInfo = enteringTyper {
+          val annotSig = newTyper(ctx.makeNonSilent(ann)).typedAnnotation(ann, Some(annotee))
+          if (pred(annotSig)) annotSig else UnmappableAnnotation // UnmappableAnnotation will be dropped in typedValDef and typedDefDef
+        }
+        ann match {
+          case treeInfo.Applied(Select(New(tpt), _), _, _) =>
+            // We can defer typechecking the arguments of annotations. This is important to avoid cycles in
+            // checking `hasAnnotation(UncheckedStable)` during typechecking.
+            def computeSymbol = enteringTyper {
+              val tptCopy = tpt.duplicate
+              val silentTyper  = newTyper(ctx.makeSilent(newtree = tptCopy))
+              // Discard errors here, we'll report them in `computeInfo`.
+              val tpt1 = silentTyper.typedTypeConstructor(tptCopy)
+              tpt1.tpe.finalResultType.typeSymbol
+            }
+            AnnotationInfo.lazily(computeSymbol, computeInfo)
+          case _ =>
+            AnnotationInfo.lazily(computeInfo)
         }
       }
 

--- a/src/library/scala/collection/immutable/OldRedBlackTree.scala
+++ b/src/library/scala/collection/immutable/OldRedBlackTree.scala
@@ -35,6 +35,7 @@ private[immutable] object RedBlackTree {
     extends Serializable {
     private def _count(tree: AnyRef) = if (tree eq null) 0 else tree.asInstanceOf[Tree[A, B]].count
     @(inline @getter) final val count: Int = 1 + _count(left) + _count(right)
+
   }
 
   @SerialVersionUID(6516527240275040268L)

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -263,7 +263,8 @@ private[collection] object NewRedBlackTree {
         validateBlackHeight(tree, h)
       } catch {
         case e: IllegalStateException => {
-          throw new IllegalStateException(s"bad tree:\n ${tree.debugToString}", e)
+          val rebuildTree = fromOrderedEntries(iterator(tree, None)(null), sizeOf(tree))
+          throw new IllegalStateException(s"bad tree:\n ${tree.debugToString}\n\n:expected: \n${rebuildTree.debugToString}", e)
         }
       }
     }

--- a/src/library/scala/reflect/ClassTag.scala
+++ b/src/library/scala/reflect/ClassTag.scala
@@ -14,6 +14,7 @@ package scala
 package reflect
 
 import java.lang.{ Class => jClass }
+import java.lang.ref.{WeakReference => jWeakReference}
 
 import scala.collection.mutable
 import scala.runtime.BoxedUnit
@@ -136,16 +137,19 @@ object ClassTag {
   val Nothing : ClassTag[scala.Nothing]    = Manifest.Nothing
   val Null    : ClassTag[scala.Null]       = Manifest.Null
 
-  private[this] val cache = new ClassValue[ClassTag[_]] {
-    override def computeValue(runtimeClass: jClass[_]): ClassTag[_] = {
+  private val cacheDisabledProp = scala.sys.Prop[String]("scala.reflect.classtag.cache.disable")
+  private[this] object cache extends ClassValue[jWeakReference[ClassTag[_]]] {
+    override def computeValue(runtimeClass: jClass[_]): jWeakReference[ClassTag[_]] =
+      new jWeakReference(computeTag(runtimeClass))
+
+    def computeTag(runtimeClass: jClass[_]): ClassTag[_] =
       runtimeClass match {
         case x if x.isPrimitive => primitiveClassTag(runtimeClass)
         case ObjectTYPE         => ClassTag.Object
         case NothingTYPE        => ClassTag.Nothing
         case NullTYPE           => ClassTag.Null
         case _                  => new GenericClassTag[AnyRef](runtimeClass)
-      }
-    }
+     }
 
     private def primitiveClassTag[T](runtimeClass: Class[_]): ClassTag[_] = runtimeClass match {
       case java.lang.Byte.TYPE      => ClassTag.Byte
@@ -168,7 +172,19 @@ object ClassTag {
     }
   }
 
-  def apply[T](runtimeClass1: jClass[_]): ClassTag[T] = cache.get(runtimeClass1).asInstanceOf[ClassTag[T]]
+  def apply[T](runtimeClass1: jClass[_]): ClassTag[T] = {
+    if (cacheDisabledProp.isSet)
+      cache.computeTag(runtimeClass1).asInstanceOf[ClassTag[T]]
+    else {
+      val ref = cache.get(runtimeClass1).asInstanceOf[jWeakReference[ClassTag[T]]]
+      var tag = ref.get
+      if (tag == null) {
+        cache.remove(runtimeClass1)
+        tag = cache.computeTag(runtimeClass1).asInstanceOf[ClassTag[T]]
+      }
+      tag
+    }
+  }
 
   def unapply[T](ctag: ClassTag[T]): Option[Class[_]] = Some(ctag.runtimeClass)
 }

--- a/test/files/jvm/interpreter.check
+++ b/test/files/jvm/interpreter.check
@@ -93,6 +93,7 @@ scala> case class Bar(n: Int)
 defined class Bar
 
 scala> implicit def foo2bar(foo: Foo) = Bar(foo.n)
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 foo2bar: (foo: Foo)Bar
 
 scala> val bar: Bar = Foo(3)
@@ -266,6 +267,7 @@ scala> xs map (x => x)
 res6: Array[_] = Array(1, 2)
 
 scala> xs map (x => (x, x))
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 res7: Array[(_$1, _$1)] forSome { type _$1 } = Array((1,1), (2,2))
 
 scala> 
@@ -351,6 +353,10 @@ defined class Term
 scala> def f(e: Exp) = e match {  // non-exhaustive warning here
   case _:Fact => 3
 }
+<console>:18: warning: match may not be exhaustive.
+It would fail on the following inputs: Exp(), Term()
+def f(e: Exp) = e match {  // non-exhaustive warning here
+                ^
 f: (e: Exp)Int
 
 scala> :quit

--- a/test/files/pos/annotation-cycle.scala
+++ b/test/files/pos/annotation-cycle.scala
@@ -1,0 +1,7 @@
+import scala.annotation.StaticAnnotation
+
+class anno(attr: Boolean) extends StaticAnnotation
+
+object Test {
+  @anno(attr = true) def attr: Int = 1
+}

--- a/test/files/pos/t11870.scala
+++ b/test/files/pos/t11870.scala
@@ -1,0 +1,60 @@
+class Annot(arg: Any) extends scala.annotation.StaticAnnotation
+
+abstract class Demo1 {
+  @Annot(x)
+  def x: String = "foo"
+}
+
+abstract class Demo2 {
+  @Annot(y)
+  def x: String = "foo"
+
+  @Annot(x)
+  def y: String = "bar"
+}
+
+class Annot1(arg: Any) extends scala.annotation.StaticAnnotation
+class Annot2(arg: Any) extends scala.annotation.StaticAnnotation
+
+abstract class Demo3 {
+  @Annot1(y)
+  def x: String = "foo"
+
+  @Annot2(x)
+  def y: String = "bar"
+}
+
+// test annotations without argument
+import scala.annotation.unchecked
+
+class C {
+  class D
+}
+
+class Test {
+  locally {
+    val c = new C
+    import c._
+    new D
+  }
+
+  locally {
+    import unchecked.uncheckedStable
+    @uncheckedStable def c = new C
+    import c._
+    new D
+  }
+
+  locally {
+    @unchecked.uncheckedStable def c = new C
+    import c._
+    new D
+  }
+
+  locally {
+    import unchecked.{uncheckedStable => uc}
+    @uc def c = new C
+    import c._
+    new D
+  }
+}

--- a/test/files/pos/unchecked-stable-cyclic-error.scala
+++ b/test/files/pos/unchecked-stable-cyclic-error.scala
@@ -1,0 +1,8 @@
+import scala.annotation.StaticAnnotation
+
+class anno(a: Any) extends StaticAnnotation
+
+object Test {
+  def foo = attr
+  @anno(foo) def attr: Int = foo
+}

--- a/test/files/run/constrained-types.check
+++ b/test/files/run/constrained-types.check
@@ -69,9 +69,11 @@ scala> var four = "four"
 four: String = four
 
 scala> val four2 = m(four) // should have an existential bound
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 four2: String @Annot(x) forSome { val x: String } = four
 
 scala> val four3 = four2   // should have the same type as four2
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 four3: String @Annot(x) forSome { val x: String } = four
 
 scala> val stuff = m("stuff") // should not crash
@@ -94,6 +96,7 @@ scala> def m = {
   val y : String @Annot(x) = x
   y
 } // x should not escape the local scope with a narrow type
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 m: String @Annot(x) forSome { val x: String }
 
 scala> 
@@ -107,6 +110,7 @@ scala> def n(y: String) = {
   }
   m("stuff".stripMargin)
 } // x should be existentially bound
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 n: (y: String)String @Annot(x) forSome { val x: String }
 
 scala> 

--- a/test/files/run/reflection-magicsymbols-repl.check
+++ b/test/files/run/reflection-magicsymbols-repl.check
@@ -19,6 +19,7 @@ scala> def test(n: Int): Unit = {
   val x = sig.asInstanceOf[MethodType].params.head
   println(x.info)
 }
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 test: (n: Int)Unit
 
 scala> for (i <- 1 to 8) test(i)

--- a/test/files/run/repl-bare-expr.check
+++ b/test/files/run/repl-bare-expr.check
@@ -1,14 +1,32 @@
 
 scala> 2 ; 3
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+2 ;;
+^
 res0: Int = 3
 
 scala> { 2 ; 3 }
+<console>:12: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+{ 2 ; 3 }
+  ^
 res1: Int = 3
 
 scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
   1 +
   2 +
   3 } ; bippy+88+11
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+    ^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+                           ^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+                                                                                  ^
 defined object Cow
 defined class Moo
 bippy: Int

--- a/test/files/run/repl-class-based-outer-pointers.check
+++ b/test/files/run/repl-class-based-outer-pointers.check
@@ -8,6 +8,9 @@ defined class Value
 defined object Value
 
 scala> class C { final case class Num(value: Double) } // here it should still warn
+<console>:11: warning: The outer reference in this type test cannot be checked at run time.
+class C { final case class Num(value: Double) } // here it should still warn
+                           ^
 defined class C
 
 scala> :quit

--- a/test/files/run/repl-no-imports-no-predef-power.check
+++ b/test/files/run/repl-no-imports-no-predef-power.check
@@ -7,9 +7,11 @@ Try :help or completions for vals._ and power._
 scala> // guarding against "error: reference to global is ambiguous"
 
 scala> global.emptyValDef  // "it is imported twice in the same scope by ..."
+warning: one deprecation (since 2.11.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res0: $r.global.noSelfType.type = private val _ = _
 
 scala> val tp = ArrayClass[scala.util.Random]    // magic with tags
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 tp: $r.global.Type = Array[scala.util.Random]
 
 scala> tp.memberType(Array_apply)                // evidence

--- a/test/files/run/repl-no-imports-no-predef.check
+++ b/test/files/run/repl-no-imports-no-predef.check
@@ -76,9 +76,15 @@ y: Int = 13
 scala> 
 
 scala> 2 ; 3
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+2 ;;
+^
 res14: Int = 3
 
 scala> { 2 ; 3 }
+<console>:12: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+{ 2 ; 3 }
+  ^
 res15: Int = 3
 
 scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
@@ -86,6 +92,18 @@ bippy = {
   1 +
   2 +
   3 } ; bippy+88+11
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+    ^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+                           ^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+                                                                                  ^
 defined object Cow
 defined class Moo
 bippy: Int
@@ -125,6 +143,12 @@ scala>   (  (2 + 2 )  )
 res24: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ;   (  (2 + 2 )  ) ;;
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ;   (  (2 + 2 )  ) ;;
+            ^
 res25: Int = 5
 
 scala> (((2 + 2)), ((2 + 2)))
@@ -139,9 +163,18 @@ res28: String = 4423
 scala> 
 
 scala> 55 ; ((2 + 2)) ; (1, 2, 3)
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; ((2 + 2)) ;;
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; ((2 + 2)) ;;
+         ^
 res29: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: scala.Int) => x + 1 ; () => ((5))
+<console>:12: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; (x: scala.Int) => x + 1 ;;
+^
 res30: () => Int = <function>
 
 scala> 
@@ -150,6 +183,9 @@ scala> () => 5
 res31: () => Int = <function>
 
 scala> 55 ; () => 5
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ;;
+^
 res32: () => Int = <function>
 
 scala> () => { class X ; new X }

--- a/test/files/run/repl-parens.check
+++ b/test/files/run/repl-parens.check
@@ -18,6 +18,12 @@ scala>   (  (2 + 2 )  )
 res5: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ;   (  (2 + 2 )  ) ;;
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ;   (  (2 + 2 )  ) ;;
+            ^
 res6: Int = 5
 
 scala> (((2 + 2)), ((2 + 2)))
@@ -32,9 +38,18 @@ res9: String = 4423
 scala> 
 
 scala> 55 ; ((2 + 2)) ; (1, 2, 3)
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; ((2 + 2)) ;;
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; ((2 + 2)) ;;
+         ^
 res10: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: Int) => x + 1 ; () => ((5))
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; (x: Int) => x + 1 ;;
+^
 res11: () => Int = <function>
 
 scala> 
@@ -43,6 +58,9 @@ scala> () => 5
 res12: () => Int = <function>
 
 scala> 55 ; () => 5
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ;;
+^
 res13: () => Int = <function>
 
 scala> () => { class X ; new X }

--- a/test/files/run/repl-power.check
+++ b/test/files/run/repl-power.check
@@ -7,9 +7,11 @@ Try :help or completions for vals._ and power._
 scala> // guarding against "error: reference to global is ambiguous"
 
 scala> global.emptyValDef  // "it is imported twice in the same scope by ..."
+warning: one deprecation (since 2.11.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res0: $r.global.noSelfType.type = private val _ = _
 
 scala> val tp = ArrayClass[scala.util.Random]    // magic with tags
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 tp: $r.global.Type = Array[scala.util.Random]
 
 scala> tp.memberType(Array_apply)                // evidence

--- a/test/files/run/t11402.check
+++ b/test/files/run/t11402.check
@@ -1,0 +1,14 @@
+
+scala> import scala.concurrent.duration._; val t = 1 second
+<console>:11: warning: postfix operator second should be enabled
+by making the implicit value scala.language.postfixOps visible.
+This can be achieved by adding the import clause 'import scala.language.postfixOps'
+or by setting the compiler option -language:postfixOps.
+See the Scaladoc for value scala.language.postfixOps for a discussion
+why the feature should be explicitly enabled.
+import scala.concurrent.duration._; val t = 1 second
+                                              ^
+import scala.concurrent.duration._
+t: scala.concurrent.duration.FiniteDuration = 1 second
+
+scala> :quit

--- a/test/files/run/t11402.scala
+++ b/test/files/run/t11402.scala
@@ -1,0 +1,12 @@
+import scala.tools.nsc.Settings
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def transformSettings(ss: Settings) = {
+    ss.feature.value = true
+    ss
+  }
+
+  // From zinc's InteractiveConsoleInterfaceSpecification "should evaluate postfix op with a warning"
+  override def code = "import scala.concurrent.duration._; val t = 1 second"
+}

--- a/test/files/run/t4172.check
+++ b/test/files/run/t4172.check
@@ -1,5 +1,6 @@
 
 scala> val c = { class C { override def toString = "C" }; ((new C, new C { def f = 2 })) }
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 c: (C, C{def f: Int}) forSome { type C <: AnyRef } = (C,C)
 
 scala> :quit

--- a/test/files/run/t4542.check
+++ b/test/files/run/t4542.check
@@ -5,6 +5,9 @@ scala> @deprecated("foooo", "ReplTest version 1.0-FINAL") class Foo() {
 defined class Foo
 
 scala> val f = new Foo
+<console>:12: warning: class Foo is deprecated (since ReplTest version 1.0-FINAL): foooo
+val f = new Foo
+            ^
 f: Foo = Bippy
 
 scala> :quit

--- a/test/files/run/t4594-repl-settings.check
+++ b/test/files/run/t4594-repl-settings.check
@@ -3,11 +3,15 @@ scala> @deprecated(message="Please don't do that.", since="Time began.") def dep
 depp: String
 
 scala> def a = depp
+warning: one deprecation (since Time began.); for details, enable `:setting -deprecation' or `:replay -deprecation'
 a: String
 
 scala> :settings -deprecation
 
 scala> def b = depp
+<console>:12: warning: method depp is deprecated (since Time began.): Please don't do that.
+def b = depp
+        ^
 b: String
 
 scala> :quit

--- a/test/files/run/t4710.check
+++ b/test/files/run/t4710.check
@@ -1,5 +1,6 @@
 
 scala> def method : String = { implicit def f(s: Symbol) = "" ; 'symbol }
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 method: String
 
 scala> :quit

--- a/test/files/run/t6329_repl.check
+++ b/test/files/run/t6329_repl.check
@@ -3,24 +3,28 @@ scala> import scala.reflect.classTag
 import scala.reflect.classTag
 
 scala> classManifest[scala.List[_]]
+warning: one deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res0: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[<?>]
 
 scala> classTag[scala.List[_]]
 res1: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List
 
 scala> classManifest[scala.collection.immutable.List[_]]
+warning: one deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res2: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[<?>]
 
 scala> classTag[scala.collection.immutable.List[_]]
 res3: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List
 
 scala> classManifest[Predef.Set[_]]
+warning: one deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res4: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set[<?>]
 
 scala> classTag[Predef.Set[_]]
 res5: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set
 
 scala> classManifest[scala.collection.immutable.Set[_]]
+warning: one deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res6: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set[<?>]
 
 scala> classTag[scala.collection.immutable.Set[_]]

--- a/test/files/run/t6329_repl_bug.check
+++ b/test/files/run/t6329_repl_bug.check
@@ -6,6 +6,7 @@ scala> import scala.reflect.runtime._
 import scala.reflect.runtime._
 
 scala> classManifest[List[_]]
+warning: one deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res0: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[<?>]
 
 scala> scala.reflect.classTag[List[_]]

--- a/test/files/run/t7319.check
+++ b/test/files/run/t7319.check
@@ -3,12 +3,15 @@ scala> class M[A]
 defined class M
 
 scala> implicit def ma0[A](a: A): M[A] = null
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 ma0: [A](a: A)M[A]
 
 scala> implicit def ma1[A](a: A): M[A] = null
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 ma1: [A](a: A)M[A]
 
 scala> def convert[F[X <: F[X]]](builder: F[_ <: F[_]]) = 0
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 convert: [F[X <: F[X]]](builder: F[_ <: F[_]])Int
 
 scala> convert(Some[Int](0))

--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -15,15 +15,33 @@ scala> val z = x * y
 z: Int = 156
 
 scala> 2 ; 3
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+2 ;;
+^
 res0: Int = 3
 
 scala> { 2 ; 3 }
+<console>:12: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+{ 2 ; 3 }
+  ^
 res1: Int = 3
 
 scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
   1 +
   2 +
   3 } ; bippy+88+11
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+    ^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+                           ^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+                                                                                  ^
 defined object Cow
 defined class Moo
 bippy: Int
@@ -63,6 +81,12 @@ scala>   (  (2 + 2 )  )
 res10: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ;   (  (2 + 2 )  ) ;;
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ;   (  (2 + 2 )  ) ;;
+            ^
 res11: Int = 5
 
 scala> (((2 + 2)), ((2 + 2)))
@@ -77,9 +101,18 @@ res14: String = 4423
 scala> 
 
 scala> 55 ; ((2 + 2)) ; (1, 2, 3)
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; ((2 + 2)) ;;
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; ((2 + 2)) ;;
+         ^
 res15: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: Int) => x + 1 ; () => ((5))
+<console>:12: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; (x: Int) => x + 1 ;;
+^
 res16: () => Int = <function>
 
 scala> 
@@ -88,6 +121,9 @@ scala> () => 5
 res17: () => Int = <function>
 
 scala> 55 ; () => 5
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ;;
+^
 res18: () => Int = <function>
 
 scala> () => { class X ; new X }

--- a/test/files/run/xMigration.check
+++ b/test/files/run/xMigration.check
@@ -10,6 +10,10 @@ res1: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 scala> :setting -Xmigration:any
 
 scala> Map(1 -> "eis").values    // warn
+<console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
+`values` returns `Iterable[V]` rather than `Iterator[V]`.
+Map(1 -> "eis").values    // warn
+                ^
 res2: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 
 scala> :setting -Xmigration:2.8
@@ -20,6 +24,10 @@ res3: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 scala> :setting -Xmigration:2.7
 
 scala> Map(1 -> "eis").values    // warn
+<console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
+`values` returns `Iterable[V]` rather than `Iterator[V]`.
+Map(1 -> "eis").values    // warn
+                ^
 res4: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 
 scala> :setting -Xmigration:2.11
@@ -30,6 +38,10 @@ res5: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 scala> :setting -Xmigration      // same as :any
 
 scala> Map(1 -> "eis").values    // warn
+<console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
+`values` returns `Iterable[V]` rather than `Iterator[V]`.
+Map(1 -> "eis").values    // warn
+                ^
 res6: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 
 scala> :quit

--- a/test/junit/scala/collection/immutable/TreeMapTest.scala
+++ b/test/junit/scala/collection/immutable/TreeMapTest.scala
@@ -8,6 +8,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.testing.AllocationTest
+import scala.util.Random
 
 @RunWith(classOf[JUnit4])
 class TreeMapTest extends AllocationTest {
@@ -97,6 +98,26 @@ class TreeMapTest extends AllocationTest {
     data foreach {
       case (k, v) =>
         assertSame(tree, nonAllocating(tree.updated(k, v)))
+    }
+  }
+  @Test
+  def randomTree() {
+    val r = new Random(0)
+    var m= TreeSet[Int]()
+    for (i <- 1 to 100000) {
+      m += r.nextInt(1000)
+      val (m1,m2) = m.splitAt(r.nextInt(1000))
+      m -= r.nextInt(1000)
+      m.drop(r.nextInt(1000))
+      m.take(r.nextInt(1000))
+      m.slice(r.nextInt(1000), r.nextInt(1000))
+      m.init
+      m.tail
+      m.from(r.nextInt(1000))
+      m.to(r.nextInt(1000))
+      m.until(r.nextInt(1000))
+      m.range(r.nextInt(1000), r.nextInt(1000))
+      //println(s"${m.size} $m")
     }
   }
   @Test def consistentEquals: Unit = {


### PR DESCRIPTION
Build atop scala/scala#9326

`TreeMapTest.randomTree`:

```
/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/bin/java -ea -Didea.test.cyclic.buffer.size=1048576 -javaagent:/Users/jz/Library/Application Support/JetBrains/Toolbox/apps/IDEA-U/ch-0/203.5784.10/IntelliJ IDEA 2020.3 EAP.app/Contents/lib/idea_rt.jar=55222:/Users/jz/Library/Application Support/JetBrains/Toolbox/apps/IDEA-U/ch-0/203.5784.10/IntelliJ IDEA 2020.3 EAP.app/Contents/bin -Dfile.encoding=UTF-8 -classpath /Users/jz/Library/Application Support/JetBrains/Toolbox/apps/IDEA-U/ch-0/203.5784.10/IntelliJ IDEA 2020.3 EAP.app/Contents/lib/idea_rt.jar:/Users/jz/Library/Application Support/JetBrains/Toolbox/apps/IDEA-U/ch-0/203.5784.10/IntelliJ IDEA 2020.3 EAP.app/Contents/plugins/junit/lib/junit5-rt.jar:/Users/jz/Library/Application Support/JetBrains/Toolbox/apps/IDEA-U/ch-0/203.5784.10/IntelliJ IDEA 2020.3 EAP.app/Contents/plugins/junit/lib/junit-rt.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/jre/lib/charsets.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/jre/lib/ext/cldrdata.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/jre/lib/ext/dnsns.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/jre/lib/ext/jaccess.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/jre/lib/ext/localedata.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/jre/lib/ext/nashorn.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/jre/lib/ext/sunec.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/jre/lib/ext/sunjce_provider.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/jre/lib/ext/sunpkcs11.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/jre/lib/ext/zipfs.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/jre/lib/jce.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/jre/lib/jfr.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/jre/lib/jsse.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/jre/lib/management-agent.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/jre/lib/resources.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/jre/lib/rt.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/lib/dt.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/lib/jconsole.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/lib/sa-jdi.jar:/Users/jz/.jabba/jdk/adopt@1.8.0-272/Contents/Home/lib/tools.jar:/Users/jz/code/scala/target/junit/test-classes:/Users/jz/code/scala/build/quick/classes/library:/Users/jz/code/scala/build/quick/classes/reflect:/Users/jz/code/scala/build/quick/classes/compiler:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/ant/ant/1.9.4/ant-1.9.4.jar:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/jline/jline/2.14.6/jline-2.14.6.jar:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.6/scala-xml_2.12-1.0.6.jar:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/fusesource/jansi/jansi/1.12/jansi-1.12.jar:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/ant/ant-launcher/1.9.4/ant-launcher-1.9.4.jar:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-asm/7.3.1-scala-1/scala-asm-7.3.1-scala-1.jar:/Users/jz/code/scala/build/quick/classes/repl:/Users/jz/code/scala/build/quick/classes/interactive:/Users/jz/code/scala/build/quick/classes/scaladoc:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/webjars/jquery/3.5.1/jquery-3.5.1.jar:/Users/jz/code/scala/build/quick/classes/partest:/Users/jz/code/scala/build/quick/classes/scalap:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/openjdk/jol/jol-core/0.13/jol-core-0.13.jar com.intellij.rt.junit.JUnitStarter -ideVersion5 -junit4 scala.collection.immutable.TreeMapTest,randomTree

java.lang.IllegalStateException: bad tree:
 BlackTree(49, ())#1633
  BlackTree(32, ())#1278
    BlackTree(13, ())#1274
      RedTree(1, ())#1172
        Empty
        Empty
      Empty
    BlackTree(39, ())#1275
      Empty
      Empty
  RedTree(271, ())#1631
    BlackTree(125, ())#1629
      BlackTree(112, ())#387
        Empty
        Empty
      BlackTree(159, ())#1107
        RedTree(149, ())#1106
          Empty
          Empty
        RedTree(254, ())#905
          Empty
          Empty
    BlackTree(387, ())#1630
      BlackTree(360, ())#1219
        RedTree(307, ())#1218
          Empty
          Empty
        Empty
      RedTree(441, ())#1626 !! Red contains Red
        BlackTree(438, ())#420
          Empty
          Empty
        RedTree(469, ())#1625
          BlackTree(457, ())#1623
            Empty
            Empty
          BlackTree(473, ())#1624
            Empty
            Empty


:expected: 
BlackTree(254, ())#1652
  BlackTree(49, ())#1642
    BlackTree(13, ())#1637
      BlackTree(1, ())#1634
        Empty
        Empty
      BlackTree(32, ())#1636
        Empty
        RedTree(39, ())#1635
          Empty
          Empty
    BlackTree(125, ())#1641
      BlackTree(112, ())#1638
        Empty
        Empty
      BlackTree(149, ())#1640
        Empty
        RedTree(159, ())#1639
          Empty
          Empty
  BlackTree(438, ())#1651
    BlackTree(307, ())#1646
      BlackTree(271, ())#1643
        Empty
        Empty
      BlackTree(360, ())#1645
        Empty
        RedTree(387, ())#1644
          Empty
          Empty
    BlackTree(457, ())#1650
      BlackTree(441, ())#1647
        Empty
        Empty
      BlackTree(469, ())#1649
        Empty
        RedTree(473, ())#1648
          Empty
          Empty
.

original input tree|b: BlackTree(616, ())#1595
  BlackTree(387, ())#1594
    RedTree(49, ())#1280
      BlackTree(32, ())#1278
        BlackTree(13, ())#1274
          RedTree(1, ())#1172
            Empty
            Empty
          Empty
        BlackTree(39, ())#1275
          Empty
          Empty
      BlackTree(125, ())#1279
        BlackTree(112, ())#387
          Empty
          Empty
        RedTree(271, ())#1220
          BlackTree(159, ())#1107
            RedTree(149, ())#1106
              Empty
              Empty
            RedTree(254, ())#905
              Empty
              Empty
          BlackTree(360, ())#1219
            RedTree(307, ())#1218
              Empty
              Empty
            Empty
    BlackTree(473, ())#1593
      RedTree(441, ())#1592
        BlackTree(438, ())#420
          Empty
          Empty
        BlackTree(457, ())#1591
          Empty
          RedTree(469, ())#1590
            Empty
            Empty
      RedTree(577, ())#1483
        BlackTree(546, ())#648
          Empty
          Empty
        BlackTree(584, ())#1482
          RedTree(580, ())#1481
            Empty
            Empty
          RedTree(615, ())#739
            Empty
            Empty
  BlackTree(794, ())#1552
    RedTree(721, ())#1441
      BlackTree(688, ())#1439
        BlackTree(643, ())#1384
          RedTree(640, ())#1383
            Empty
            Empty
          Empty
        BlackTree(693, ())#1435
          Empty
          Empty
      BlackTree(767, ())#1440
        BlackTree(758, ())#1436
          Empty
          Empty
        BlackTree(786, ())#946
          Empty
          Empty
    BlackTree(905, ())#1551
      RedTree(888, ())#1342
        BlackTree(814, ())#1340
          Empty
          Empty
        BlackTree(889, ())#1341
          Empty
          Empty
      RedTree(986, ())#1550
        BlackTree(957, ())#1549
          Empty
          RedTree(971, ())#1548
            Empty
            Empty
        BlackTree(999, ())#806
          Empty
          Empty


	at scala.collection.immutable.NewRedBlackTree$.scala$collection$immutable$NewRedBlackTree$$validate(RedBlackTree.scala:273)
	at scala.collection.immutable.NewRedBlackTree$.result(RedBlackTree.scala:232)
	at scala.collection.immutable.NewRedBlackTree$.to(RedBlackTree.scala:192)
	at scala.collection.immutable.TreeSet.to(TreeSet.scala:243)
	at scala.collection.immutable.TreeMapTest.$anonfun$randomTree$1(TreeMapTest.scala:117)
	at scala.collection.immutable.TreeMapTest.$anonfun$randomTree$1$adapted(TreeMapTest.scala:107)
	at scala.collection.immutable.Range.foreach(Range.scala:158)
	at scala.collection.immutable.TreeMapTest.randomTree(TreeMapTest.scala:107)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:220)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:53)
Caused by: java.lang.IllegalStateException: at RedTree#1626 (k=441) right is also red 469
	at scala.collection.immutable.NewRedBlackTree$.checkAdjacentRed$1(RedBlackTree.scala:247)
	at scala.collection.immutable.NewRedBlackTree$.scala$collection$immutable$NewRedBlackTree$$validate(RedBlackTree.scala:267)
	... 29 more
Caused by: java.lang.Throwable: tree created stack trace
	at scala.collection.immutable.NewRedBlackTree$Tree.<init>(RedBlackTree.scala:619)
	at scala.collection.immutable.NewRedBlackTree$Tree.withRight(RedBlackTree.scala:787)
	at scala.collection.immutable.NewRedBlackTree$.balanceRight(RedBlackTree.scala:445)
	at scala.collection.immutable.NewRedBlackTree$.upd(RedBlackTree.scala:467)
	at scala.collection.immutable.NewRedBlackTree$.doTo(RedBlackTree.scala:499)
	at scala.collection.immutable.NewRedBlackTree$.doTo(RedBlackTree.scala:497)
	at scala.collection.immutable.NewRedBlackTree$.doTo(RedBlackTree.scala:496)
	... 28 more

```