### PR TITLE
WIP runtime reflection on protobuf f-bounds cycle

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4652,7 +4652,7 @@ trait Types
     def this(msg: String) = this(NoPosition, msg)
 
     final override def fillInStackTrace() =
-      if (settings.debug) super.fillInStackTrace() else this
+      super.fillInStackTrace()
   }
 
   // TODO: RecoverableCyclicReference should be separated from TypeError,

--- a/test/files/run/t12038.scala
+++ b/test/files/run/t12038.scala
@@ -1,0 +1,33 @@
+import scala.reflect.runtime.currentMirror
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto
+
+import scala.tools.nsc.util
+
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package p {
+  object Hello {
+    def fromJava(t: FileDescriptorProto): Unit = ()
+  }
+}
+
+object Test{
+  def main(args: Array[String]): Unit = {
+    def f() =
+      try currentMirror.reflectModule(currentMirror.staticModule("p.Hello$")).instance
+      catch { case t: Throwable => s"ugh, ${util.stackTraceString(t)}" }
+
+    println(f())
+    println(f())
+  }
+}

--- a/test/files/run/t12038a/J_1.java
+++ b/test/files/run/t12038a/J_1.java
@@ -1,0 +1,66 @@
+package p1;
+
+public class J_1 {
+    public static abstract class Builder<MessageType extends GeneratedMessageLite<MessageType, BuilderType>, BuilderType extends Builder<MessageType, BuilderType>>
+            extends AbstractMessageLite.Builder<MessageType, BuilderType> {
+
+    }
+
+    public abstract class GeneratedMessageLite<MessageType extends GeneratedMessageLite<MessageType, BuilderType>, BuilderType extends Builder<MessageType, BuilderType>>
+            extends AbstractMessageLite<MessageType, BuilderType> {
+
+    }
+
+    public interface MessageLite
+            extends MessageLiteOrBuilder {
+        public static interface Builder
+                extends MessageLiteOrBuilder, Cloneable {
+
+        }
+
+    }
+
+    public static final class FileDescriptorProto
+            extends GeneratedMessageV3
+            implements FileDescriptorProtoOrBuilder {
+
+    }
+
+    public static interface FileDescriptorProtoOrBuilder
+            extends MessageOrBuilder {
+
+    }
+    public abstract class GeneratedMessageV3
+            extends AbstractMessage
+            implements java.io.Serializable {
+    }
+
+    public static abstract class AbstractMessageLite<MessageType extends AbstractMessageLite<MessageType, BuilderType>, BuilderType extends Builder<MessageType, BuilderType>>
+            implements MessageLite {
+        public abstract class Builder<MessageType extends AbstractMessageLite<MessageType, BuilderType>, BuilderType extends Builder<MessageType, BuilderType>>
+                implements MessageLite.Builder {
+
+        }
+    }
+
+    public static abstract class AbstractMessage
+            extends AbstractMessageLite
+            implements Message {
+
+    }
+
+    public interface MessageLiteOrBuilder {
+    }
+
+    public interface Message
+            extends MessageLite, MessageOrBuilder {
+
+        public static interface Builder
+                extends MessageLite.Builder, MessageOrBuilder {
+        }
+    }
+    public interface MessageOrBuilder
+            extends MessageLiteOrBuilder {
+
+    }
+}


### PR DESCRIPTION
``` pbpaste | grep -v '\tat '
ugh, scala.reflect.internal.Types$TypeError: while completing class Hello$
Caused by: scala.reflect.internal.Types$TypeError: During typeToScala(param parameterized type of, final com.google.protobuf.DescriptorProtos$FileDescriptorProto t)(class com.google.protobuf.DescriptorProtos$FileDescriptorProto)
	... 47 more
Caused by: scala.reflect.internal.Types$TypeError: while completing class DescriptorProtos
	... 72 more
Caused by: scala.reflect.internal.Types$TypeError: During typeToScala(field generic type, private static final com.google.protobuf.GeneratedMessageV3$FieldAccessorTable com.google.protobuf.DescriptorProtos.internal_static_google_protobuf_FileDescriptorSet_fieldAccessorTable)(class com.google.protobuf.GeneratedMessageV3$FieldAccessorTable)
	... 98 more
Caused by: scala.reflect.internal.Types$TypeError: while completing class GeneratedMessageV3
	... 120 more
Caused by: scala.reflect.internal.Types$TypeError: During typeToScala(param parameterized type of, com.google.protobuf.AbstractMessage$BuilderParent arg0)(interface com.google.protobuf.AbstractMessage$BuilderParent)
	... 146 more
Caused by: scala.reflect.internal.Types$TypeError: During typeToScala(generic superclass, class com.google.protobuf.AbstractMessageLite)(class com.google.protobuf.AbstractMessageLite)
	... 171 more
Caused by: scala.reflect.internal.Types$TypeError: During typeToScala(type var upper bound, BuilderType)(com.google.protobuf.AbstractMessageLite$Builder<MessageType, BuilderType>)
	... 204 more
Caused by: scala.reflect.internal.Types$TypeError: During typeToScala(generic applied type owner of, com.google.protobuf.AbstractMessageLite$Builder<MessageType, BuilderType>)(class com.google.protobuf.AbstractMessageLite)
	... 230 more
Caused by: scala.reflect.internal.Symbols$CyclicReference: illegal cyclic reference involving type BuilderType
	... 231 more

```

```
ugh, scala.reflect.internal.Types$TypeError: while completing class Hello$
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.complete(JavaMirrors.scala:795)
	at scala.reflect.internal.Symbols$Symbol.completeInfo(Symbols.scala:1551)
	at scala.reflect.internal.Symbols$Symbol.info(Symbols.scala:1514)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$13.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$super$info(SynchronizedSymbols.scala:221)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.$anonfun$info$1(SynchronizedSymbols.scala:158)
	at scala.reflect.runtime.Gil.gilSynchronized(Gil.scala:31)
	at scala.reflect.runtime.Gil.gilSynchronized$(Gil.scala:26)
	at scala.reflect.runtime.JavaUniverse.gilSynchronized(JavaUniverse.scala:30)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.gilSynchronizedIfNotThreadsafe(SynchronizedSymbols.scala:149)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.gilSynchronizedIfNotThreadsafe$(SynchronizedSymbols.scala:145)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$13.gilSynchronizedIfNotThreadsafe(SynchronizedSymbols.scala:221)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.info(SynchronizedSymbols.scala:158)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.info$(SynchronizedSymbols.scala:158)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$13.info(SynchronizedSymbols.scala:221)
	at scala.reflect.internal.Symbols$Symbol.initialize(Symbols.scala:1698)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.getFlag(SynchronizedSymbols.scala:153)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.getFlag$(SynchronizedSymbols.scala:152)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$13.getFlag(SynchronizedSymbols.scala:221)
	at scala.reflect.internal.Symbols$Symbol.hasFlag(Symbols.scala:737)
	at scala.reflect.internal.Symbols$Symbol.hasFlag(Symbols.scala:739)
	at scala.reflect.internal.Symbols$Symbol.isStatic(Symbols.scala:994)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.reflectModule(JavaMirrors.scala:230)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.reflectModule(JavaMirrors.scala:69)
	at Test$.f$1(t12038.scala:27)
	at Test$.main(t12038.scala:30)
	at Test.main(t12038.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at scala.reflect.internal.util.ScalaClassLoader.$anonfun$run$2(ScalaClassLoader.scala:106)
	at scala.reflect.internal.util.ScalaClassLoader.asContext(ScalaClassLoader.scala:41)
	at scala.reflect.internal.util.ScalaClassLoader.asContext$(ScalaClassLoader.scala:37)
	at scala.reflect.internal.util.ScalaClassLoader$URLClassLoader.asContext(ScalaClassLoader.scala:132)
	at scala.reflect.internal.util.ScalaClassLoader.run(ScalaClassLoader.scala:106)
	at scala.reflect.internal.util.ScalaClassLoader.run$(ScalaClassLoader.scala:98)
	at scala.reflect.internal.util.ScalaClassLoader$URLClassLoader.run(ScalaClassLoader.scala:132)
	at scala.tools.nsc.CommonRunner.run(ObjectRunner.scala:28)
	at scala.tools.nsc.CommonRunner.run$(ObjectRunner.scala:27)
	at scala.tools.nsc.ObjectRunner$.run(ObjectRunner.scala:45)
	at scala.tools.nsc.CommonRunner.runAndCatch(ObjectRunner.scala:35)
	at scala.tools.nsc.CommonRunner.runAndCatch$(ObjectRunner.scala:34)
	at scala.tools.nsc.ObjectRunner$.runAndCatch(ObjectRunner.scala:45)
	at scala.tools.nsc.MainGenericRunner.runTarget$1(MainGenericRunner.scala:73)
	at scala.tools.nsc.MainGenericRunner.run$1(MainGenericRunner.scala:92)
	at scala.tools.nsc.MainGenericRunner.process(MainGenericRunner.scala:103)
	at scala.tools.nsc.MainGenericRunner$.main(MainGenericRunner.scala:108)
	at scala.tools.nsc.MainGenericRunner.main(MainGenericRunner.scala)
Caused by: scala.reflect.internal.Types$TypeError: During typeToScala(param parameterized type of, final com.google.protobuf.DescriptorProtos$FileDescriptorProto t)(class com.google.protobuf.DescriptorProtos$FileDescriptorProto)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.typeToScalaDescribed(JavaMirrors.scala:1155)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.$anonfun$jparamsAsScala$1(JavaMirrors.scala:1260)
	at scala.collection.immutable.List.map(List.scala:293)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.jparamsAsScala(JavaMirrors.scala:1254)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.jmethodAsScala1(JavaMirrors.scala:1215)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.$anonfun$jmethodAsScala$1(JavaMirrors.scala:1208)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.$anonfun$toScala$1(JavaMirrors.scala:137)
	at scala.reflect.runtime.TwoWayCaches$TwoWayCache.$anonfun$toScala$1(TwoWayCaches.scala:50)
	at scala.reflect.runtime.Gil.gilSynchronized(Gil.scala:31)
	at scala.reflect.runtime.Gil.gilSynchronized$(Gil.scala:26)
	at scala.reflect.runtime.JavaUniverse.gilSynchronized(JavaUniverse.scala:30)
	at scala.reflect.runtime.TwoWayCaches$TwoWayCache.toScala(TwoWayCaches.scala:46)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.toScala(JavaMirrors.scala:135)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.scala$reflect$runtime$JavaMirrors$JavaMirror$$jmethodAsScala(JavaMirrors.scala:1208)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.$anonfun$completeRest$6(JavaMirrors.scala:833)
	at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
	at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33)
	at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:198)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.$anonfun$completeRest$4(JavaMirrors.scala:833)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.$anonfun$completeRest$1(JavaMirrors.scala:842)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at scala.reflect.runtime.Gil.gilSynchronized(Gil.scala:31)
	at scala.reflect.runtime.Gil.gilSynchronized$(Gil.scala:26)
	at scala.reflect.runtime.JavaUniverse.gilSynchronized(JavaUniverse.scala:30)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.completeRest(JavaMirrors.scala:800)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.complete(JavaMirrors.scala:792)
	... 47 more
Caused by: scala.reflect.internal.Types$TypeError: while completing class DescriptorProtos
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.complete(JavaMirrors.scala:795)
	at scala.reflect.internal.Symbols$Symbol.completeInfo(Symbols.scala:1551)
	at scala.reflect.internal.Symbols$Symbol.info(Symbols.scala:1514)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$8.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$super$info(SynchronizedSymbols.scala:206)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.$anonfun$info$1(SynchronizedSymbols.scala:158)
	at scala.reflect.runtime.Gil.gilSynchronized(Gil.scala:31)
	at scala.reflect.runtime.Gil.gilSynchronized$(Gil.scala:26)
	at scala.reflect.runtime.JavaUniverse.gilSynchronized(JavaUniverse.scala:30)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.gilSynchronizedIfNotThreadsafe(SynchronizedSymbols.scala:149)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.gilSynchronizedIfNotThreadsafe$(SynchronizedSymbols.scala:145)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$8.gilSynchronizedIfNotThreadsafe(SynchronizedSymbols.scala:206)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.info(SynchronizedSymbols.scala:158)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.info$(SynchronizedSymbols.scala:158)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$8.info(SynchronizedSymbols.scala:206)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.coreLookup$1(JavaMirrors.scala:1043)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.lookupClass$1(JavaMirrors.scala:1049)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.classToScala1(JavaMirrors.scala:1054)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.$anonfun$classToScala$1(JavaMirrors.scala:1031)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.$anonfun$toScala$1(JavaMirrors.scala:137)
	at scala.reflect.runtime.TwoWayCaches$TwoWayCache.$anonfun$toScala$1(TwoWayCaches.scala:50)
	at scala.reflect.runtime.Gil.gilSynchronized(Gil.scala:31)
	at scala.reflect.runtime.Gil.gilSynchronized$(Gil.scala:26)
	at scala.reflect.runtime.JavaUniverse.gilSynchronized(JavaUniverse.scala:30)
	at scala.reflect.runtime.TwoWayCaches$TwoWayCache.toScala(TwoWayCaches.scala:46)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.toScala(JavaMirrors.scala:135)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.classToScala(JavaMirrors.scala:1031)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.typeToScalaDescribed(JavaMirrors.scala:1138)
	... 72 more
Caused by: scala.reflect.internal.Types$TypeError: During typeToScala(field generic type, private static final com.google.protobuf.GeneratedMessageV3$FieldAccessorTable com.google.protobuf.DescriptorProtos.internal_static_google_protobuf_FileDescriptorSet_fieldAccessorTable)(class com.google.protobuf.GeneratedMessageV3$FieldAccessorTable)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.typeToScalaDescribed(JavaMirrors.scala:1155)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.jfieldAsScala1(JavaMirrors.scala:1188)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.$anonfun$jfieldAsScala$1(JavaMirrors.scala:1183)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.$anonfun$toScala$1(JavaMirrors.scala:137)
	at scala.reflect.runtime.TwoWayCaches$TwoWayCache.$anonfun$toScala$1(TwoWayCaches.scala:50)
	at scala.reflect.runtime.Gil.gilSynchronized(Gil.scala:31)
	at scala.reflect.runtime.Gil.gilSynchronized$(Gil.scala:26)
	at scala.reflect.runtime.JavaUniverse.gilSynchronized(JavaUniverse.scala:30)
	at scala.reflect.runtime.TwoWayCaches$TwoWayCache.toScala(TwoWayCaches.scala:46)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.toScala(JavaMirrors.scala:135)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.scala$reflect$runtime$JavaMirrors$JavaMirror$$jfieldAsScala(JavaMirrors.scala:1183)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.$anonfun$completeRest$5(JavaMirrors.scala:832)
	at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
	at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33)
	at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:198)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.$anonfun$completeRest$4(JavaMirrors.scala:832)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.$anonfun$completeRest$1(JavaMirrors.scala:842)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at scala.reflect.runtime.Gil.gilSynchronized(Gil.scala:31)
	at scala.reflect.runtime.Gil.gilSynchronized$(Gil.scala:26)
	at scala.reflect.runtime.JavaUniverse.gilSynchronized(JavaUniverse.scala:30)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.completeRest(JavaMirrors.scala:800)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.complete(JavaMirrors.scala:792)
	... 98 more
Caused by: scala.reflect.internal.Types$TypeError: while completing class GeneratedMessageV3
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.complete(JavaMirrors.scala:795)
	at scala.reflect.internal.Symbols$Symbol.completeInfo(Symbols.scala:1551)
	at scala.reflect.internal.Symbols$Symbol.info(Symbols.scala:1514)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$8.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$super$info(SynchronizedSymbols.scala:206)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.$anonfun$info$1(SynchronizedSymbols.scala:158)
	at scala.reflect.runtime.Gil.gilSynchronized(Gil.scala:31)
	at scala.reflect.runtime.Gil.gilSynchronized$(Gil.scala:26)
	at scala.reflect.runtime.JavaUniverse.gilSynchronized(JavaUniverse.scala:30)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.gilSynchronizedIfNotThreadsafe(SynchronizedSymbols.scala:149)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.gilSynchronizedIfNotThreadsafe$(SynchronizedSymbols.scala:145)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$8.gilSynchronizedIfNotThreadsafe(SynchronizedSymbols.scala:206)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.info(SynchronizedSymbols.scala:158)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.info$(SynchronizedSymbols.scala:158)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$8.info(SynchronizedSymbols.scala:206)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.coreLookup$1(JavaMirrors.scala:1043)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.lookupClass$1(JavaMirrors.scala:1049)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.classToScala1(JavaMirrors.scala:1054)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.$anonfun$classToScala$1(JavaMirrors.scala:1031)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.$anonfun$toScala$1(JavaMirrors.scala:137)
	at scala.reflect.runtime.TwoWayCaches$TwoWayCache.$anonfun$toScala$1(TwoWayCaches.scala:50)
	at scala.reflect.runtime.Gil.gilSynchronized(Gil.scala:31)
	at scala.reflect.runtime.Gil.gilSynchronized$(Gil.scala:26)
	at scala.reflect.runtime.JavaUniverse.gilSynchronized(JavaUniverse.scala:30)
	at scala.reflect.runtime.TwoWayCaches$TwoWayCache.toScala(TwoWayCaches.scala:46)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.toScala(JavaMirrors.scala:135)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.classToScala(JavaMirrors.scala:1031)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.typeToScalaDescribed(JavaMirrors.scala:1138)
	... 120 more
Caused by: scala.reflect.internal.Types$TypeError: During typeToScala(param parameterized type of, com.google.protobuf.AbstractMessage$BuilderParent arg0)(interface com.google.protobuf.AbstractMessage$BuilderParent)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.typeToScalaDescribed(JavaMirrors.scala:1155)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.$anonfun$jparamsAsScala$1(JavaMirrors.scala:1260)
	at scala.collection.immutable.List.map(List.scala:293)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.jparamsAsScala(JavaMirrors.scala:1254)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.jmethodAsScala1(JavaMirrors.scala:1215)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.$anonfun$jmethodAsScala$1(JavaMirrors.scala:1208)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.$anonfun$toScala$1(JavaMirrors.scala:137)
	at scala.reflect.runtime.TwoWayCaches$TwoWayCache.$anonfun$toScala$1(TwoWayCaches.scala:50)
	at scala.reflect.runtime.Gil.gilSynchronized(Gil.scala:31)
	at scala.reflect.runtime.Gil.gilSynchronized$(Gil.scala:26)
	at scala.reflect.runtime.JavaUniverse.gilSynchronized(JavaUniverse.scala:30)
	at scala.reflect.runtime.TwoWayCaches$TwoWayCache.toScala(TwoWayCaches.scala:46)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.toScala(JavaMirrors.scala:135)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.scala$reflect$runtime$JavaMirrors$JavaMirror$$jmethodAsScala(JavaMirrors.scala:1208)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.$anonfun$completeRest$6(JavaMirrors.scala:833)
	at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
	at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33)
	at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:198)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.$anonfun$completeRest$4(JavaMirrors.scala:833)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.$anonfun$completeRest$1(JavaMirrors.scala:842)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at scala.reflect.runtime.Gil.gilSynchronized(Gil.scala:31)
	at scala.reflect.runtime.Gil.gilSynchronized$(Gil.scala:26)
	at scala.reflect.runtime.JavaUniverse.gilSynchronized(JavaUniverse.scala:30)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.completeRest(JavaMirrors.scala:800)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.complete(JavaMirrors.scala:792)
	... 146 more
Caused by: scala.reflect.internal.Types$TypeError: During typeToScala(generic superclass, class com.google.protobuf.AbstractMessageLite)(class com.google.protobuf.AbstractMessageLite)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.typeToScalaDescribed(JavaMirrors.scala:1155)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.$anonfun$completeRest$1(JavaMirrors.scala:810)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at scala.reflect.runtime.Gil.gilSynchronized(Gil.scala:31)
	at scala.reflect.runtime.Gil.gilSynchronized$(Gil.scala:26)
	at scala.reflect.runtime.JavaUniverse.gilSynchronized(JavaUniverse.scala:30)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter.completeRest(JavaMirrors.scala:800)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$FromJavaClassCompleter$LazyPolyType.complete(JavaMirrors.scala:849)
	at scala.reflect.internal.Symbols$Symbol.completeInfo(Symbols.scala:1551)
	at scala.reflect.internal.Symbols$Symbol.info(Symbols.scala:1514)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$8.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$super$info(SynchronizedSymbols.scala:206)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.$anonfun$info$1(SynchronizedSymbols.scala:158)
	at scala.reflect.runtime.Gil.gilSynchronized(Gil.scala:31)
	at scala.reflect.runtime.Gil.gilSynchronized$(Gil.scala:26)
	at scala.reflect.runtime.JavaUniverse.gilSynchronized(JavaUniverse.scala:30)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.gilSynchronizedIfNotThreadsafe(SynchronizedSymbols.scala:149)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.gilSynchronizedIfNotThreadsafe$(SynchronizedSymbols.scala:145)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$8.gilSynchronizedIfNotThreadsafe(SynchronizedSymbols.scala:206)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.info(SynchronizedSymbols.scala:158)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.info$(SynchronizedSymbols.scala:158)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$8.info(SynchronizedSymbols.scala:206)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.coreLookup$1(JavaMirrors.scala:1043)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.lookupClass$1(JavaMirrors.scala:1049)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.classToScala1(JavaMirrors.scala:1054)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.$anonfun$classToScala$1(JavaMirrors.scala:1031)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.$anonfun$toScala$1(JavaMirrors.scala:137)
	at scala.reflect.runtime.TwoWayCaches$TwoWayCache.$anonfun$toScala$1(TwoWayCaches.scala:50)
	at scala.reflect.runtime.Gil.gilSynchronized(Gil.scala:31)
	at scala.reflect.runtime.Gil.gilSynchronized$(Gil.scala:26)
	at scala.reflect.runtime.JavaUniverse.gilSynchronized(JavaUniverse.scala:30)
	at scala.reflect.runtime.TwoWayCaches$TwoWayCache.toScala(TwoWayCaches.scala:46)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.toScala(JavaMirrors.scala:135)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.classToScala(JavaMirrors.scala:1031)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.typeToScalaDescribed(JavaMirrors.scala:1138)
	... 171 more
Caused by: scala.reflect.internal.Types$TypeError: During typeToScala(type var upper bound, BuilderType)(com.google.protobuf.AbstractMessageLite$Builder<MessageType, BuilderType>)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.typeToScalaDescribed(JavaMirrors.scala:1155)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$TypeParamCompleter.$anonfun$complete$1(JavaMirrors.scala:706)
	at scala.collection.immutable.List.map(List.scala:293)
	at scala.reflect.runtime.JavaMirrors$JavaMirror$TypeParamCompleter.complete(JavaMirrors.scala:706)
	at scala.reflect.internal.Symbols$Symbol.completeInfo(Symbols.scala:1551)
	at scala.reflect.internal.Symbols$Symbol.info(Symbols.scala:1514)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$4.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$super$info(SynchronizedSymbols.scala:194)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.$anonfun$info$1(SynchronizedSymbols.scala:158)
	at scala.reflect.runtime.Gil.gilSynchronized(Gil.scala:31)
	at scala.reflect.runtime.Gil.gilSynchronized$(Gil.scala:26)
	at scala.reflect.runtime.JavaUniverse.gilSynchronized(JavaUniverse.scala:30)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.gilSynchronizedIfNotThreadsafe(SynchronizedSymbols.scala:149)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.gilSynchronizedIfNotThreadsafe$(SynchronizedSymbols.scala:145)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$4.gilSynchronizedIfNotThreadsafe(SynchronizedSymbols.scala:194)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.info(SynchronizedSymbols.scala:158)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.info$(SynchronizedSymbols.scala:158)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$4.info(SynchronizedSymbols.scala:194)
	at scala.reflect.internal.Types.$anonfun$typeParamsToExistentials$1(Types.scala:3922)
	at scala.collection.immutable.List.map(List.scala:297)
	at scala.reflect.internal.Types.typeParamsToExistentials(Types.scala:3921)
	at scala.reflect.internal.Types.typeParamsToExistentials$(Types.scala:3920)
	at scala.reflect.internal.SymbolTable.typeParamsToExistentials(SymbolTable.scala:28)
	at scala.reflect.internal.Types.typeParamsToExistentials(Types.scala:3928)
	at scala.reflect.internal.Types.typeParamsToExistentials$(Types.scala:3927)
	at scala.reflect.internal.SymbolTable.typeParamsToExistentials(SymbolTable.scala:28)
	at scala.reflect.internal.tpe.TypeMaps$$anon$1.apply(TypeMaps.scala:360)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.typeToScalaDescribed(JavaMirrors.scala:1139)
	... 204 more
Caused by: scala.reflect.internal.Types$TypeError: During typeToScala(generic applied type owner of, com.google.protobuf.AbstractMessageLite$Builder<MessageType, BuilderType>)(class com.google.protobuf.AbstractMessageLite)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.typeToScalaDescribed(JavaMirrors.scala:1155)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.typeToScalaDescribed(JavaMirrors.scala:1144)
	... 230 more
Caused by: scala.reflect.internal.Symbols$CyclicReference: illegal cyclic reference involving type BuilderType
	at scala.reflect.internal.Symbols$Symbol.$anonfun$completeInfo$3(Symbols.scala:1532)
	at scala.Function0.apply$mcV$sp(Function0.scala:39)
	at scala.reflect.internal.Symbols$Symbol.lock(Symbols.scala:580)
	at scala.reflect.internal.Symbols$Symbol.completeInfo(Symbols.scala:1530)
	at scala.reflect.internal.Symbols$Symbol.info(Symbols.scala:1514)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$4.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$super$info(SynchronizedSymbols.scala:194)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.$anonfun$info$1(SynchronizedSymbols.scala:158)
	at scala.reflect.runtime.Gil.gilSynchronized(Gil.scala:31)
	at scala.reflect.runtime.Gil.gilSynchronized$(Gil.scala:26)
	at scala.reflect.runtime.JavaUniverse.gilSynchronized(JavaUniverse.scala:30)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.gilSynchronizedIfNotThreadsafe(SynchronizedSymbols.scala:149)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.gilSynchronizedIfNotThreadsafe$(SynchronizedSymbols.scala:145)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$4.gilSynchronizedIfNotThreadsafe(SynchronizedSymbols.scala:194)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.info(SynchronizedSymbols.scala:158)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.info$(SynchronizedSymbols.scala:158)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$4.info(SynchronizedSymbols.scala:194)
	at scala.reflect.internal.Types.$anonfun$typeParamsToExistentials$1(Types.scala:3922)
	at scala.collection.immutable.List.map(List.scala:297)
	at scala.reflect.internal.Types.typeParamsToExistentials(Types.scala:3921)
	at scala.reflect.internal.Types.typeParamsToExistentials$(Types.scala:3920)
	at scala.reflect.internal.SymbolTable.typeParamsToExistentials(SymbolTable.scala:28)
	at scala.reflect.internal.Types.typeParamsToExistentials(Types.scala:3928)
	at scala.reflect.internal.Types.typeParamsToExistentials$(Types.scala:3927)
	at scala.reflect.internal.SymbolTable.typeParamsToExistentials(SymbolTable.scala:28)
	at scala.reflect.internal.tpe.TypeMaps$$anon$1.apply(TypeMaps.scala:360)
	at scala.reflect.runtime.JavaMirrors$JavaMirror.typeToScalaDescribed(JavaMirrors.scala:1139)
	... 231 more

```