### PR TITLE
WIP Make Iterable.from(someIterator) preserve laziness

### DIFF
--- a/src/library/scala/collection/immutable/Iterable.scala
+++ b/src/library/scala/collection/immutable/Iterable.scala
@@ -32,6 +32,7 @@ trait Iterable[+A] extends collection.Iterable[A]
 object Iterable extends IterableFactory.Delegate[Iterable](List) {
   override def from[E](it: IterableOnce[E]): Iterable[E] = it match {
     case iterable: Iterable[E] => iterable
+    case it: Iterator[E] => LazyList.from(it)
     case _ => super.from(it)
   }
 }


### PR DESCRIPTION
Restoring the 2.12 behaviour:

```
% scala --scala-version 2.12.17
Welcome to Scala 2.12.17 (OpenJDK 64-Bit Server VM, Java 17.0.13).
Type in expressions for evaluation. Or try :help.

scala> Iterator.continually(1)
res0: Iterator[Int] = <iterator>

scala> Iterator.continually(1).toIterable
res1: Iterable[Int] = Stream(1, ?)
```