### PR TITLE
Delegate null-check-then-equals to Objects.equals

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -1584,25 +1584,10 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
           genCallMethod(Object_equals, InvokeStyle.Virtual, pos)
           genCZJUMP(success, failure, TestOp.NE, BOOL, targetIfNoJump)
         } else {
-          // l == r -> if (l eq null) r eq null else l.equals(r)
-          val eqEqTempLocal = locals.makeLocal(ObjectRef, nme.EQEQ_LOCAL_VAR.toString)
-          val lNull    = new asm.Label
-          val lNonNull = new asm.Label
-
+          // l == r -> Objects.equals(l, r)
           genLoad(l, ObjectRef)
           genLoad(r, ObjectRef)
-          locals.store(eqEqTempLocal)
-          bc dup ObjectRef
-          genCZJUMP(lNull, lNonNull, TestOp.EQ, ObjectRef, targetIfNoJump = lNull)
-
-          markProgramPoint(lNull)
-          bc drop ObjectRef
-          locals.load(eqEqTempLocal)
-          genCZJUMP(success, failure, TestOp.EQ, ObjectRef, targetIfNoJump = lNonNull)
-
-          markProgramPoint(lNonNull)
-          locals.load(eqEqTempLocal)
-          genCallMethod(Object_equals, InvokeStyle.Virtual, pos)
+          genCallMethod(Objects_equals, InvokeStyle.Static, pos)
           genCZJUMP(success, failure, TestOp.NE, BOOL, targetIfNoJump)
         }
       }

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -290,9 +290,10 @@ trait Definitions extends api.StandardDefinitions {
     }
 
     // top types
-    lazy val AnyClass    = enterNewClass(ScalaPackageClass, tpnme.Any, Nil, ABSTRACT).markAllCompleted()
-    lazy val AnyRefClass = newAlias(ScalaPackageClass, tpnme.AnyRef, ObjectTpe).markAllCompleted()
-    lazy val ObjectClass = getRequiredClass("java.lang.Object")
+    lazy val AnyClass      = enterNewClass(ScalaPackageClass, tpnme.Any, Nil, ABSTRACT).markAllCompleted()
+    lazy val AnyRefClass   = newAlias(ScalaPackageClass, tpnme.AnyRef, ObjectTpe).markAllCompleted()
+    lazy val ObjectClass   = getRequiredClass("java.lang.Object")
+    lazy val ObjectsModule = getRequiredModule("java.util.Objects")
 
     // Cached types for core monomorphic classes
     lazy val AnyRefTpe       = AnyRefClass.tpe
@@ -1285,6 +1286,7 @@ trait Definitions extends api.StandardDefinitions {
     def Object_equals    = getMemberMethod(ObjectClass, nme.equals_)
     def Object_hashCode  = getMemberMethod(ObjectClass, nme.hashCode_)
     def Object_toString  = getMemberMethod(ObjectClass, nme.toString_)
+    def Objects_equals   = getMemberMethod(ObjectsModule, nme.equals_)
 
     // boxed classes
     lazy val ObjectRefClass         = requiredClass[scala.runtime.ObjectRef[_]]

--- a/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
@@ -106,16 +106,11 @@ class BytecodeTest extends BytecodeTesting {
       Label(7), Op(ICONST_2), Op(IRETURN)))
 
     // t3: Array == is translated to reference equality, AnyRef == to null checks and equals
-    assertSameCode(getMethod(c, "t3"), List(
-      // Array ==
-      VarOp(ALOAD, 1), VarOp(ALOAD, 2), Jump(IF_ACMPEQ, Label(23)),
-      // AnyRef ==
-      VarOp(ALOAD, 2), VarOp(ALOAD, 1), VarOp(ASTORE, 3), Op(DUP), Jump(IFNONNULL, Label(14)),
-      Op(POP), VarOp(ALOAD, 3), Jump(IFNULL, Label(19)), Jump(GOTO, Label(23)),
-      Label(14), VarOp(ALOAD, 3), InvokeVirtual("java/lang/Object", "equals", "(Ljava/lang/Object;)Z"), Jump(IFEQ, Label(23)),
-      Label(19), Op(ICONST_1), Jump(GOTO, Label(26)),
-      Label(23), Op(ICONST_0),
-      Label(26), Op(IRETURN)))
+    assertSameCode(getMethod(c, "t3"),  List(
+      VarOp(ALOAD, 1), VarOp(ALOAD, 2), Jump(IF_ACMPEQ, Label(11)),
+      VarOp(ALOAD, 2), VarOp(ALOAD, 1),
+      Invoke(INVOKESTATIC, "java/util/Objects", "equals", "(Ljava/lang/Object;Ljava/lang/Object;)Z", itf = false),
+      Jump(IFEQ, Label(11)), Op(ICONST_1), Jump(GOTO, Label(14)), Label(11), Op(ICONST_0), Label(14), Op(IRETURN)))
 
     val t4t5 = List(
       VarOp(ALOAD, 1), Jump(IFNULL, Label(6)),


### PR DESCRIPTION
Motivation is to remove avoidable synthetic branches/instructions
for null data that are intepreted as uncovered code by JaCoCo etc.

Bytecode is also reduced.

Note that if either operand is potential `Number` or `Character`,
the backend delegates to `BoxesRuntime.equals` which handles Scala
semantic edge cases for boxed primitives. This PR does not change
that at all.

Before:

```
  public boolean test1(java.lang.String, java.lang.String);
    descriptor: (Ljava/lang/String;Ljava/lang/String;)Z
    flags: (0x0001) ACC_PUBLIC
    Code:
      stack=2, locals=4, args_size=3
         0: aload_1
         1: aload_2
         2: astore_3
         3: dup
         4: ifnonnull     15
         7: pop
         8: aload_3
         9: ifnull        22
        12: goto          26
        15: aload_3
        16: invokevirtual #20                 // Method java/lang/Object.equals:(Ljava/lang/Object;)Z
        19: ifeq          26
        22: iconst_1
        23: goto          27
        26: iconst_0
        27: ireturn
```

After

```
  public boolean test1(java.lang.String, java.lang.String);
    descriptor: (Ljava/lang/String;Ljava/lang/String;)Z
    flags: (0x0001) ACC_PUBLIC
    Code:
      stack=2, locals=3, args_size=3
         0: aload_1
         1: aload_2
         2: invokestatic  #22                 // Method java/util/Objects.equals:(Ljava/lang/Object;Ljava/lang/Object;)Z
         5: ifeq          12
         8: iconst_1
         9: goto          13
        12: iconst_0
        13: ireturn
```
